### PR TITLE
Obtain balances for all validators.

### DIFF
--- a/prysmgrpc/validators.go
+++ b/prysmgrpc/validators.go
@@ -268,7 +268,9 @@ func (s *Service) validatorsByPubKeys(ctx context.Context, stateID string, valid
 	// reduce our validators to those that Prysm recognises.
 	balancePubKeys := make([][]byte, 0, len(known))
 	for k := range known {
-		balancePubKeys = append(balancePubKeys, k[:])
+		pubKey := make([]byte, 48)
+		copy(pubKey, k[:])
+		balancePubKeys = append(balancePubKeys, pubKey)
 	}
 
 	// Fetch the balances


### PR DESCRIPTION
When multiple validator balances were requested in the same call a variable was re-used, resulting in only the last of the validators' balances being obtained.  This addresses the issue by creating a new variable for each public key rather than reusing the loop variable.