### PR TITLE
Add fallback if no active multi clients.

### DIFF
--- a/multi/parameters.go
+++ b/multi/parameters.go
@@ -28,6 +28,7 @@ type parameters struct {
 	clients   []consensusclient.Service
 	addresses []string
 	timeout   time.Duration
+	fallback  bool
 }
 
 // Parameter is the interface for service parameters.
@@ -73,6 +74,13 @@ func WithClients(clients []consensusclient.Service) Parameter {
 func WithAddresses(addresses []string) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.addresses = addresses
+	})
+}
+
+// WithFallback enables falling back to inactive clients if no active clients available.
+func WithFallback() Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.fallback = true
 	})
 }
 

--- a/multi/service_test.go
+++ b/multi/service_test.go
@@ -60,6 +60,16 @@ func TestService(t *testing.T) {
 			err: "No providers active, cannot proceed",
 		},
 		{
+			name: "AllClientsInactiveFallback",
+			params: []multi.Parameter{
+				multi.WithLogLevel(zerolog.Disabled),
+				multi.WithClients([]client.Service{
+					inactiveconsensusclient1,
+				}),
+				multi.WithFallback(),
+			},
+		},
+		{
 			name: "Good",
 			params: []multi.Parameter{
 				multi.WithLogLevel(zerolog.Disabled),


### PR DESCRIPTION
Adds the `WithFallback` parameter to `multi.Service` and fixes issue with `multi.doColl` that returns `nil,nil` when no active providers are available.

Fallback results in `doCall` to also attempt each inactive provider when no active providers are available. This seamlessly actives any actually active providers. This is quite common since providers are deactivated on a single error, which can be due to sporadic timeouts or other sporadic network issues.   