### PR TITLE
add Root function on versioned validator registration

### DIFF
--- a/api/versionedsignedvalidatorregistration.go
+++ b/api/versionedsignedvalidatorregistration.go
@@ -80,3 +80,16 @@ func (v *VersionedSignedValidatorRegistration) PubKey() (phase0.BLSPubKey, error
 		return phase0.BLSPubKey{}, errors.New("unsupported version")
 	}
 }
+
+// Root returns the root of the validator registration
+func (v *VersionedSignedValidatorRegistration) Root() (phase0.Root, error) {
+	switch v.Version {
+	case spec.BuilderVersionV1:
+		if v.V1 == nil {
+			return phase0.Root{}, errors.New("no V1 registration")
+		}
+		return v.V1.Message.HashTreeRoot()
+	default:
+		return phase0.Root{}, errors.New("unsupported version")
+	}
+}

--- a/api/versionedvalidatorregistration.go
+++ b/api/versionedvalidatorregistration.go
@@ -85,3 +85,16 @@ func (v *VersionedValidatorRegistration) PubKey() (phase0.BLSPubKey, error) {
 		return phase0.BLSPubKey{}, errors.New("unsupported version")
 	}
 }
+
+// Root returns the root of the validator registration.
+func (v *VersionedValidatorRegistration) Root() (phase0.Root, error) {
+	switch v.Version {
+	case spec.BuilderVersionV1:
+		if v.V1 == nil {
+			return phase0.Root{}, errors.New("no V1 registration")
+		}
+		return v.V1.HashTreeRoot()
+	default:
+		return phase0.Root{}, errors.New("unsupported version")
+	}
+}

--- a/http/spec_conformance_test.go
+++ b/http/spec_conformance_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build conformance
 // +build conformance
 
 package http_test
@@ -45,6 +46,7 @@ func TestSpecConformance(t *testing.T) {
 		"DOMAIN_RANDAO":                         phase0.DomainType{},
 		"DOMAIN_SELECTION_PROOF":                phase0.DomainType{},
 		"DOMAIN_VOLUNTARY_EXIT":                 phase0.DomainType{},
+		"DOMAIN_APPLICATION_BUILDER":            phase0.DomainType{},
 		"EFFECTIVE_BALANCE_INCREMENT":           uint64(0),
 		"EJECTION_BALANCE":                      uint64(0),
 		"EPOCHS_PER_ETH1_VOTING_PERIOD":         uint64(0),


### PR DESCRIPTION
- Adding Root functions for validator registration
- Adding DOMAIN_APPLICATION_BUILDER

Resolves Issues
https://github.com/attestantio/go-eth2-client/issues/18