### PR TITLE
fix: align ValidatorStatus with spec

### DIFF
--- a/api/v1/validator_test.go
+++ b/api/v1/validator_test.go
@@ -39,32 +39,32 @@ func TestValidatorJSON(t *testing.T) {
 		},
 		{
 			name:  "IndexMissing",
-			input: []byte(`{"balance":"32000000000","status":"Active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
+			input: []byte(`{"balance":"32000000000","status":"active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
 			err:   "index missing",
 		},
 		{
 			name:  "IndexWrongType",
-			input: []byte(`{"index":true,"balance":"32000000000","status":"Active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
+			input: []byte(`{"index":true,"balance":"32000000000","status":"active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
 			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field validatorJSON.index of type string",
 		},
 		{
 			name:  "IndexInvalid",
-			input: []byte(`{"index":"-1","balance":"32000000000","status":"Active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
+			input: []byte(`{"index":"-1","balance":"32000000000","status":"active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
 			err:   "invalid value for index: strconv.ParseUint: parsing \"-1\": invalid syntax",
 		},
 		{
 			name:  "BalanceMissing",
-			input: []byte(`{"index":"1","status":"Active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
+			input: []byte(`{"index":"1","status":"active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
 			err:   "balance missing",
 		},
 		{
 			name:  "BalanceWrongType",
-			input: []byte(`{"index":"1","balance":true,"status":"Active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
+			input: []byte(`{"index":"1","balance":true,"status":"active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
 			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field validatorJSON.balance of type string",
 		},
 		{
 			name:  "BalanceInvalid",
-			input: []byte(`{"index":"1","balance":"-1","status":"Active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
+			input: []byte(`{"index":"1","balance":"-1","status":"active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
 			err:   "invalid value for balance: strconv.ParseUint: parsing \"-1\": invalid syntax",
 		},
 		{
@@ -79,22 +79,22 @@ func TestValidatorJSON(t *testing.T) {
 		},
 		{
 			name:  "ValidatorMissing",
-			input: []byte(`{"index":"1","balance":"32000000000","status":"Active_ongoing"}`),
+			input: []byte(`{"index":"1","balance":"32000000000","status":"active_ongoing"}`),
 			err:   "validator missing",
 		},
 		{
 			name:  "ValidatorWrongType",
-			input: []byte(`{"index":"1","balance":"32000000000","status":"Active_ongoing","validator":true}`),
+			input: []byte(`{"index":"1","balance":"32000000000","status":"active_ongoing","validator":true}`),
 			err:   "invalid JSON: invalid JSON: json: cannot unmarshal bool into Go value of type phase0.validatorJSON",
 		},
 		{
 			name:  "ValidatorInvalid",
-			input: []byte(`{"index":"1","balance":"32000000000","status":"Active_ongoing","validator":{}}`),
+			input: []byte(`{"index":"1","balance":"32000000000","status":"active_ongoing","validator":{}}`),
 			err:   "invalid JSON: public key missing",
 		},
 		{
 			name:  "Good",
-			input: []byte(`{"index":"1","balance":"32000000000","status":"Active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
+			input: []byte(`{"index":"1","balance":"32000000000","status":"active_ongoing","validator":{"pubkey":"0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b","withdrawal_credentials":"0x00ec7ef7780c9d151597924036262dd28dc60e1228f4da6fecf9d402cb3f3594","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}`),
 		},
 	}
 

--- a/api/v1/validatorstate.go
+++ b/api/v1/validatorstate.go
@@ -47,16 +47,16 @@ const (
 )
 
 var validatorStateStrings = [...]string{
-	"Unknown",
-	"Pending_initialized",
-	"Pending_queued",
-	"Active_ongoing",
-	"Active_exiting",
-	"Active_slashed",
-	"Exited_unslashed",
-	"Exited_slashed",
-	"Withdrawal_possible",
-	"Withdrawal_done",
+	"unknown",
+	"pending_initialized",
+	"pending_queued",
+	"active_ongoing",
+	"active_exiting",
+	"active_slashed",
+	"exited_unslashed",
+	"exited_slashed",
+	"withdrawal_possible",
+	"withdrawal_done",
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/api/v1/validatorstate_test.go
+++ b/api/v1/validatorstate_test.go
@@ -39,19 +39,19 @@ func TestValidatorStateJSON(t *testing.T) {
 	}{
 		{
 			name:       "PendingQueued",
-			input:      []byte(`"Pending_queued"`),
+			input:      []byte(`"pending_queued"`),
 			isPending:  true,
 			hasBalance: true,
 		},
 		{
 			name:       "PendingInitialized",
-			input:      []byte(`"Pending_initialized"`),
+			input:      []byte(`"pending_initialized"`),
 			isPending:  true,
 			hasBalance: true,
 		},
 		{
 			name:         "ActiveOngoing",
-			input:        []byte(`"Active_ongoing"`),
+			input:        []byte(`"active_ongoing"`),
 			isActive:     true,
 			hasActivated: true,
 			isAttesting:  true,
@@ -59,7 +59,7 @@ func TestValidatorStateJSON(t *testing.T) {
 		},
 		{
 			name:         "ActiveExiting",
-			input:        []byte(`"Active_exiting"`),
+			input:        []byte(`"active_exiting"`),
 			isActive:     true,
 			hasActivated: true,
 			isAttesting:  true,
@@ -67,14 +67,14 @@ func TestValidatorStateJSON(t *testing.T) {
 		},
 		{
 			name:         "ActiveSlashed",
-			input:        []byte(`"Active_slashed"`),
+			input:        []byte(`"active_slashed"`),
 			isActive:     true,
 			hasActivated: true,
 			hasBalance:   true,
 		},
 		{
 			name:         "ExitedUnslashed",
-			input:        []byte(`"Exited_unslashed"`),
+			input:        []byte(`"exited_unslashed"`),
 			hasActivated: true,
 			isExited:     true,
 			hasExited:    true,
@@ -82,7 +82,7 @@ func TestValidatorStateJSON(t *testing.T) {
 		},
 		{
 			name:         "ExitedSlashed",
-			input:        []byte(`"Exited_slashed"`),
+			input:        []byte(`"exited_slashed"`),
 			hasActivated: true,
 			isExited:     true,
 			hasExited:    true,
@@ -90,21 +90,21 @@ func TestValidatorStateJSON(t *testing.T) {
 		},
 		{
 			name:         "WithdrawalPossible",
-			input:        []byte(`"Withdrawal_possible"`),
+			input:        []byte(`"withdrawal_possible"`),
 			hasActivated: true,
 			hasExited:    true,
 			hasBalance:   true,
 		},
 		{
 			name:         "WithdrawalDone",
-			input:        []byte(`"Withdrawal_done"`),
+			input:        []byte(`"withdrawal_done"`),
 			hasActivated: true,
 			hasExited:    true,
 			hasBalance:   true,
 		},
 		{
 			name:  "Unknown",
-			input: []byte(`"Unknown"`),
+			input: []byte(`"unknown"`),
 		},
 		{
 			name:  "Invalid",


### PR DESCRIPTION
Change `ValidatorStatus` string representation to all lowercase (e.g. from `Active_ongoing` to `active_ongoing`), according to [spec](https://github.com/ethereum/beacon-APIs/blob/18cb6ff152b33a5f34c377f00611821942955c82/types/api.yaml#L31-L42).