### PR TITLE
add structured http errors

### DIFF
--- a/http/http_test.go
+++ b/http/http_test.go
@@ -1,0 +1,35 @@
+package http_test
+
+import (
+	"context"
+	"github.com/attestantio/go-eth2-client/http"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	nethttp "net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestError(t *testing.T) {
+	status := nethttp.StatusTeapot
+	data := []byte("data")
+	srv := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write(data)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := http.New(ctx, http.WithAddress(srv.URL))
+
+	require.NotNil(t, err)
+	require.Equal(t, "failed to confirm node connection: failed to fetch genesis: failed to request genesis: GET failed with status 418: data", err.Error())
+
+	var httpError http.Error
+	require.True(t, errors.As(err, &httpError))
+	require.Equal(t, status, httpError.StatusCode)
+	require.Equal(t, data, httpError.Data)
+	require.Equal(t, nethttp.MethodGet, httpError.Method)
+	require.Equal(t, "/eth/v1/beacon/genesis", httpError.Endpoint)
+}


### PR DESCRIPTION
Adds structured errors so users that do structured logging can extract fields and ensure consistent group-able error messages allowing proper metrics and alerts on errors.