### PR TITLE
http: lowercase node version before comparing

### DIFF
--- a/http/nodeclient.go
+++ b/http/nodeclient.go
@@ -28,13 +28,13 @@ func (s *Service) NodeClient(ctx context.Context) (string, error) {
 	nodeVersion = strings.ToLower(nodeVersion)
 
 	switch {
-	case strings.HasPrefix(nodeVersion, "lighthouse"):
+	case strings.HasPrefix(strings.ToLower(nodeVersion), "lighthouse"):
 		return "lighthouse", nil
-	case strings.HasPrefix(nodeVersion, "nimbus"):
+	case strings.HasPrefix(strings.ToLower(nodeVersion), "nimbus"):
 		return "nimbus", nil
-	case strings.HasPrefix(nodeVersion, "prysm"):
+	case strings.HasPrefix(strings.ToLower(nodeVersion), "prysm"):
 		return "prysm", nil
-	case strings.HasPrefix(nodeVersion, "teku"):
+	case strings.HasPrefix(strings.ToLower(nodeVersion), "teku"):
 		return "teku", nil
 	default:
 		return nodeVersion, nil

--- a/http/nodeclient.go
+++ b/http/nodeclient.go
@@ -28,13 +28,13 @@ func (s *Service) NodeClient(ctx context.Context) (string, error) {
 	nodeVersion = strings.ToLower(nodeVersion)
 
 	switch {
-	case strings.HasPrefix(strings.ToLower(nodeVersion), "lighthouse"):
+	case strings.HasPrefix(nodeVersion, "lighthouse"):
 		return "lighthouse", nil
-	case strings.HasPrefix(strings.ToLower(nodeVersion), "nimbus"):
+	case strings.HasPrefix(nodeVersion, "nimbus"):
 		return "nimbus", nil
-	case strings.HasPrefix(strings.ToLower(nodeVersion), "prysm"):
+	case strings.HasPrefix(nodeVersion, "prysm"):
 		return "prysm", nil
-	case strings.HasPrefix(strings.ToLower(nodeVersion), "teku"):
+	case strings.HasPrefix(nodeVersion, "teku"):
 		return "teku", nil
 	default:
 		return nodeVersion, nil

--- a/http/validators.go
+++ b/http/validators.go
@@ -52,13 +52,13 @@ func (s *Service) indexChunkSize(ctx context.Context) int {
 	nodeVersion, _ := s.NodeVersion(ctx)
 
 	switch {
-	case strings.Contains(nodeVersion, "lighthouse"):
+	case strings.Contains(strings.ToLower(nodeVersion), "lighthouse"):
 		return indexChunkSizes["lighthouse"]
-	case strings.Contains(nodeVersion, "ninbus"):
+	case strings.Contains(strings.ToLower(nodeVersion), "ninbus"):
 		return indexChunkSizes["nimbus"]
-	case strings.Contains(nodeVersion, "prysm"):
+	case strings.Contains(strings.ToLower(nodeVersion), "prysm"):
 		return indexChunkSizes["prysm"]
-	case strings.Contains(nodeVersion, "teku"):
+	case strings.Contains(strings.ToLower(nodeVersion), "teku"):
 		return indexChunkSizes["teku"]
 	default:
 		return indexChunkSizes["default"]

--- a/http/validators.go
+++ b/http/validators.go
@@ -54,7 +54,7 @@ func (s *Service) indexChunkSize(ctx context.Context) int {
 	switch {
 	case strings.Contains(strings.ToLower(nodeVersion), "lighthouse"):
 		return indexChunkSizes["lighthouse"]
-	case strings.Contains(strings.ToLower(nodeVersion), "ninbus"):
+	case strings.Contains(strings.ToLower(nodeVersion), "nimbus"):
 		return indexChunkSizes["nimbus"]
 	case strings.Contains(strings.ToLower(nodeVersion), "prysm"):
 		return indexChunkSizes["prysm"]

--- a/http/validators.go
+++ b/http/validators.go
@@ -51,14 +51,16 @@ func (s *Service) indexChunkSize(ctx context.Context) int {
 	// If this errors it will use the default so not a concern.
 	nodeVersion, _ := s.NodeVersion(ctx)
 
+	nodeVersion = strings.ToLower(nodeVersion)
+
 	switch {
-	case strings.Contains(strings.ToLower(nodeVersion), "lighthouse"):
+	case strings.Contains(nodeVersion, "lighthouse"):
 		return indexChunkSizes["lighthouse"]
-	case strings.Contains(strings.ToLower(nodeVersion), "nimbus"):
+	case strings.Contains(nodeVersion, "nimbus"):
 		return indexChunkSizes["nimbus"]
-	case strings.Contains(strings.ToLower(nodeVersion), "prysm"):
+	case strings.Contains(nodeVersion, "prysm"):
 		return indexChunkSizes["prysm"]
-	case strings.Contains(strings.ToLower(nodeVersion), "teku"):
+	case strings.Contains(nodeVersion, "teku"):
 		return indexChunkSizes["teku"]
 	default:
 		return indexChunkSizes["default"]

--- a/http/validatorsbypubkey.go
+++ b/http/validatorsbypubkey.go
@@ -51,14 +51,16 @@ func (s *Service) pubKeyChunkSize(ctx context.Context) int {
 	// If this errors it will use the default so not a concern.
 	nodeVersion, _ := s.NodeVersion(ctx)
 
+	nodeVersion = strings.ToLower(nodeVersion)
+
 	switch {
-	case strings.Contains(strings.ToLower(nodeVersion), "lighthouse"):
+	case strings.Contains(nodeVersion, "lighthouse"):
 		return pubKeyChunkSizes["lighthouse"]
-	case strings.Contains(strings.ToLower(nodeVersion), "nimbus"):
+	case strings.Contains(nodeVersion, "nimbus"):
 		return pubKeyChunkSizes["nimbus"]
-	case strings.Contains(strings.ToLower(nodeVersion), "prysm"):
+	case strings.Contains(nodeVersion, "prysm"):
 		return pubKeyChunkSizes["prysm"]
-	case strings.Contains(strings.ToLower(nodeVersion), "teku"):
+	case strings.Contains(nodeVersion, "teku"):
 		return pubKeyChunkSizes["teku"]
 	default:
 		return pubKeyChunkSizes["default"]

--- a/http/validatorsbypubkey.go
+++ b/http/validatorsbypubkey.go
@@ -52,13 +52,13 @@ func (s *Service) pubKeyChunkSize(ctx context.Context) int {
 	nodeVersion, _ := s.NodeVersion(ctx)
 
 	switch {
-	case strings.Contains(nodeVersion, "lighthouse"):
+	case strings.Contains(strings.ToLower(nodeVersion), "lighthouse"):
 		return pubKeyChunkSizes["lighthouse"]
-	case strings.Contains(nodeVersion, "ninbus"):
+	case strings.Contains(strings.ToLower(nodeVersion), "ninbus"):
 		return pubKeyChunkSizes["nimbus"]
-	case strings.Contains(nodeVersion, "prysm"):
+	case strings.Contains(strings.ToLower(nodeVersion), "prysm"):
 		return pubKeyChunkSizes["prysm"]
-	case strings.Contains(nodeVersion, "teku"):
+	case strings.Contains(strings.ToLower(nodeVersion), "teku"):
 		return pubKeyChunkSizes["teku"]
 	default:
 		return pubKeyChunkSizes["default"]

--- a/http/validatorsbypubkey.go
+++ b/http/validatorsbypubkey.go
@@ -54,7 +54,7 @@ func (s *Service) pubKeyChunkSize(ctx context.Context) int {
 	switch {
 	case strings.Contains(strings.ToLower(nodeVersion), "lighthouse"):
 		return pubKeyChunkSizes["lighthouse"]
-	case strings.Contains(strings.ToLower(nodeVersion), "ninbus"):
+	case strings.Contains(strings.ToLower(nodeVersion), "nimbus"):
 		return pubKeyChunkSizes["nimbus"]
 	case strings.Contains(strings.ToLower(nodeVersion), "prysm"):
 		return pubKeyChunkSizes["prysm"]


### PR DESCRIPTION
Use `strings.Lower` to check client node versions. This solves the problem when clients send mixed case versions, for example, lighthouse returns `Lighthouse/v3.4.0-38514c0/x86_64-linux`. Also fixes typo in `nimbus`.

category: bug 