### PR TITLE
Add support for extra HTTP headers in requests

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -65,7 +65,9 @@ func (s *Service) get(ctx context.Context, endpoint string) (io.Reader, error) {
 		cancel()
 		return nil, errors.Wrap(err, "failed to create GET request")
 	}
+	s.addExtraHeaders(req)
 	req.Header.Set("Accept", "application/json")
+
 	resp, err := s.client.Do(req)
 	if err != nil {
 		cancel()
@@ -128,8 +130,10 @@ func (s *Service) post(ctx context.Context, endpoint string, body io.Reader) (io
 		cancel()
 		return nil, errors.Wrap(err, "failed to create POST request")
 	}
+	s.addExtraHeaders(req)
 	req.Header.Set("Content-type", "application/json")
 	req.Header.Set("Accept", "application/json")
+
 	resp, err := s.client.Do(req)
 	if err != nil {
 		cancel()
@@ -159,6 +163,12 @@ func (s *Service) post(ctx context.Context, endpoint string, body io.Reader) (io
 	log.Trace().Str("response", string(data)).Msg("POST response")
 
 	return bytes.NewReader(data), nil
+}
+
+func (s *Service) addExtraHeaders(req *http.Request) {
+	for k, v := range s.extraHeaders {
+		req.Header.Add(k, v)
+	}
 }
 
 // responseMetadata returns metadata related to responses.

--- a/http/parameters.go
+++ b/http/parameters.go
@@ -26,6 +26,7 @@ type parameters struct {
 	timeout         time.Duration
 	indexChunkSize  int
 	pubKeyChunkSize int
+	extraHeaders    map[string]string
 }
 
 // Parameter is the interface for service parameters.
@@ -74,6 +75,12 @@ func WithPubKeyChunkSize(pubKeyChunkSize int) Parameter {
 	})
 }
 
+func WithExtraHeaders(headers map[string]string) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.extraHeaders = headers
+	})
+}
+
 // parseAndCheckParameters parses and checks parameters to ensure that mandatory parameters are present and correct.
 func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	parameters := parameters{
@@ -81,6 +88,7 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 		timeout:         2 * time.Second,
 		indexChunkSize:  -1,
 		pubKeyChunkSize: -1,
+		extraHeaders:    make(map[string]string),
 	}
 	for _, p := range params {
 		if params != nil {

--- a/http/service.go
+++ b/http/service.go
@@ -62,6 +62,7 @@ type Service struct {
 	// User-specified chunk sizes.
 	userIndexChunkSize  int
 	userPubKeyChunkSize int
+	extraHeaders        map[string]string
 }
 
 // New creates a new Ethereum 2 client service, connecting with a standard HTTP.
@@ -112,6 +113,7 @@ func New(ctx context.Context, params ...Parameter) (eth2client.Service, error) {
 		timeout:             parameters.timeout,
 		userIndexChunkSize:  parameters.indexChunkSize,
 		userPubKeyChunkSize: parameters.pubKeyChunkSize,
+		extraHeaders:        parameters.extraHeaders,
 	}
 
 	// Fetch static values to confirm the connection is good.


### PR DESCRIPTION
For the purposes of services like Blockdaemon Ubiquity which require authentication, its general good idea to support extra headers in the requests.