### PR TITLE
Add versioned block requests

### DIFF
--- a/api/v1/deneb/blindedblobsidecar.go
+++ b/api/v1/deneb/blindedblobsidecar.go
@@ -26,7 +26,7 @@ type BlindedBlobSidecar struct {
 	BlockRoot       phase0.Root `ssz-size:"32"`
 	Index           deneb.BlobIndex
 	Slot            phase0.Slot
-	BlockParentRoot phase0.Root ` ssz-size:"32"`
+	BlockParentRoot phase0.Root `ssz-size:"32"`
 	ProposerIndex   phase0.ValidatorIndex
 	BlobRoot        phase0.Root         `ssz-size:"32"`
 	KzgCommitment   deneb.KzgCommitment `ssz-size:"48"`

--- a/api/versionedblindedblockrequest.go
+++ b/api/versionedblindedblockrequest.go
@@ -1,0 +1,308 @@
+// Copyright © 2023 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"errors"
+
+	apiv1bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
+	apiv1capella "github.com/attestantio/go-eth2-client/api/v1/capella"
+	apiv1deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// VersionedBlindedBlockRequest contains a versioned signed blinded beacon block.
+type VersionedBlindedBlockRequest struct {
+	Version   spec.DataVersion
+	Bellatrix *apiv1bellatrix.SignedBlindedBeaconBlock
+	Capella   *apiv1capella.SignedBlindedBeaconBlock
+	Deneb     *apiv1deneb.SignedBlindedBlockContents
+}
+
+// Slot returns the slot of the signed beacon block.
+func (v *VersionedBlindedBlockRequest) Slot() (phase0.Slot, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil {
+			return 0, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Slot, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil {
+			return 0, errors.New("no capella block")
+		}
+		return v.Capella.Message.Slot, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlindedBlock == nil || v.Deneb.SignedBlindedBlock.Message == nil {
+			return 0, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.Slot, nil
+	default:
+		return 0, errors.New("unsupported version")
+	}
+}
+
+// Attestations returns the attestations of the beacon block.
+func (v *VersionedBlindedBlockRequest) Attestations() ([]*phase0.Attestation, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil {
+			return nil, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.Attestations, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil {
+			return nil, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.Attestations, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlindedBlock == nil || v.Deneb.SignedBlindedBlock.Message == nil || v.Deneb.SignedBlindedBlock.Message.Body == nil {
+			return nil, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.Body.Attestations, nil
+	default:
+		return nil, errors.New("unsupported version")
+	}
+}
+
+// Root returns the root of the beacon block.
+func (v *VersionedBlindedBlockRequest) Root() (phase0.Root, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return phase0.Root{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.HashTreeRoot()
+	case spec.DataVersionCapella:
+		if v.Capella == nil {
+			return phase0.Root{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.HashTreeRoot()
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil {
+			return phase0.Root{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.HashTreeRoot()
+	default:
+		return phase0.Root{}, errors.New("unsupported version")
+	}
+}
+
+// BodyRoot returns the body root of the beacon block.
+func (v *VersionedBlindedBlockRequest) BodyRoot() (phase0.Root, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return phase0.Root{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.HashTreeRoot()
+	case spec.DataVersionCapella:
+		if v.Capella == nil {
+			return phase0.Root{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.HashTreeRoot()
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil {
+			return phase0.Root{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.Body.HashTreeRoot()
+	default:
+		return phase0.Root{}, errors.New("unsupported version")
+	}
+}
+
+// ParentRoot returns the parent root of the beacon block.
+func (v *VersionedBlindedBlockRequest) ParentRoot() (phase0.Root, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return phase0.Root{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.ParentRoot, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil {
+			return phase0.Root{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.ParentRoot, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil {
+			return phase0.Root{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.ParentRoot, nil
+	default:
+		return phase0.Root{}, errors.New("unsupported version")
+	}
+}
+
+// StateRoot returns the state root of the beacon block.
+func (v *VersionedBlindedBlockRequest) StateRoot() (phase0.Root, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return phase0.Root{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.StateRoot, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil {
+			return phase0.Root{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.StateRoot, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil {
+			return phase0.Root{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.StateRoot, nil
+	default:
+		return phase0.Root{}, errors.New("unsupported version")
+	}
+}
+
+// AttesterSlashings returns the attester slashings of the beacon block.
+func (v *VersionedBlindedBlockRequest) AttesterSlashings() ([]*phase0.AttesterSlashing, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return nil, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.AttesterSlashings, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil {
+			return nil, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.AttesterSlashings, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil {
+			return nil, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.Body.AttesterSlashings, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// ProposerSlashings returns the proposer slashings of the beacon block.
+func (v *VersionedBlindedBlockRequest) ProposerSlashings() ([]*phase0.ProposerSlashing, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return nil, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.ProposerSlashings, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil {
+			return nil, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.ProposerSlashings, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil {
+			return nil, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.Body.ProposerSlashings, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// ProposerIndex returns the proposer index of the beacon block.
+func (v *VersionedBlindedBlockRequest) ProposerIndex() (phase0.ValidatorIndex, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil {
+			return 0, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.ProposerIndex, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil {
+			return 0, errors.New("no capella block")
+		}
+		return v.Capella.Message.ProposerIndex, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlindedBlock.Message == nil {
+			return 0, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.ProposerIndex, nil
+	default:
+		return 0, errors.New("unknown version")
+	}
+}
+
+// ExecutionBlockHash returns the hash of the beacon block.
+func (v *VersionedBlindedBlockRequest) ExecutionBlockHash() (phase0.Hash32, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil || v.Bellatrix.Message.Body.ExecutionPayloadHeader == nil {
+			return phase0.Hash32{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.ExecutionPayloadHeader.BlockHash, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil || v.Capella.Message.Body.ExecutionPayloadHeader == nil {
+			return phase0.Hash32{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.ExecutionPayloadHeader.BlockHash, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlindedBlock.Message == nil || v.Deneb.SignedBlindedBlock.Message.Body == nil || v.Deneb.SignedBlindedBlock.Message.Body.ExecutionPayloadHeader == nil {
+			return phase0.Hash32{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.Body.ExecutionPayloadHeader.BlockHash, nil
+	default:
+		return phase0.Hash32{}, errors.New("unknown version")
+	}
+}
+
+// ExecutionBlockNumber returns the block number of the beacon block.
+func (v *VersionedBlindedBlockRequest) ExecutionBlockNumber() (uint64, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil || v.Bellatrix.Message.Body.ExecutionPayloadHeader == nil {
+			return 0, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.ExecutionPayloadHeader.BlockNumber, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil || v.Capella.Message.Body.ExecutionPayloadHeader == nil {
+			return 0, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.ExecutionPayloadHeader.BlockNumber, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlindedBlock.Message == nil || v.Deneb.SignedBlindedBlock.Message.Body == nil || v.Deneb.SignedBlindedBlock.Message.Body.ExecutionPayloadHeader == nil {
+			return 0, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Message.Body.ExecutionPayloadHeader.BlockNumber, nil
+	default:
+		return 0, errors.New("unknown version")
+	}
+}
+
+// Signature returns the signature of the beacon block.
+func (v *VersionedBlindedBlockRequest) BeaconBlockSignature() (phase0.BLSSignature, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return phase0.BLSSignature{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Signature, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil {
+			return phase0.BLSSignature{}, errors.New("no capella block")
+		}
+		return v.Capella.Signature, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlindedBlock == nil {
+			return phase0.BLSSignature{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlindedBlock.Signature, nil
+	default:
+		return phase0.BLSSignature{}, errors.New("unknown version")
+	}
+}

--- a/api/versionedblockrequest.go
+++ b/api/versionedblockrequest.go
@@ -67,12 +67,12 @@ func (v *VersionedBlockRequest) ExecutionBlockHash() (phase0.Hash32, error) {
 		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil || v.Capella.Message.Body.ExecutionPayload == nil {
 			return phase0.Hash32{}, errors.New("no capella block")
 		}
-		return v.Bellatrix.Message.Body.ExecutionPayload.BlockHash, nil
+		return v.Capella.Message.Body.ExecutionPayload.BlockHash, nil
 	case spec.DataVersionDeneb:
 		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil || v.Deneb.SignedBlock.Message.Body == nil || v.Deneb.SignedBlock.Message.Body.ExecutionPayload == nil {
 			return phase0.Hash32{}, errors.New("no denb block")
 		}
-		return v.Bellatrix.Message.Body.ExecutionPayload.BlockHash, nil
+		return v.Deneb.SignedBlock.Message.Body.ExecutionPayload.BlockHash, nil
 	default:
 		return phase0.Hash32{}, errors.New("unknown version")
 	}

--- a/api/versionedblockrequest.go
+++ b/api/versionedblockrequest.go
@@ -1,0 +1,286 @@
+// Copyright © 2023 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"errors"
+
+	apiv1deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// VersionedBlockRequest contains a versioned signed beacon block request.
+type VersionedBlockRequest struct {
+	Version   spec.DataVersion
+	Bellatrix *bellatrix.SignedBeaconBlock
+	Capella   *capella.SignedBeaconBlock
+	Deneb     *apiv1deneb.SignedBlockContents
+}
+
+// Slot returns the slot of the signed beacon block.
+func (v *VersionedBlockRequest) Slot() (phase0.Slot, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil {
+			return 0, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Slot, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil {
+			return 0, errors.New("no capella block")
+		}
+		return v.Capella.Message.Slot, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil {
+			return 0, errors.New("no denb block")
+		}
+		return v.Deneb.SignedBlock.Message.Slot, nil
+	default:
+		return 0, errors.New("unknown version")
+	}
+}
+
+// ExecutionBlockHash returns the block hash of the beacon block.
+func (v *VersionedBlockRequest) ExecutionBlockHash() (phase0.Hash32, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil || v.Bellatrix.Message.Body.ExecutionPayload == nil {
+			return phase0.Hash32{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.ExecutionPayload.BlockHash, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil || v.Capella.Message.Body.ExecutionPayload == nil {
+			return phase0.Hash32{}, errors.New("no capella block")
+		}
+		return v.Bellatrix.Message.Body.ExecutionPayload.BlockHash, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil || v.Deneb.SignedBlock.Message.Body == nil || v.Deneb.SignedBlock.Message.Body.ExecutionPayload == nil {
+			return phase0.Hash32{}, errors.New("no denb block")
+		}
+		return v.Bellatrix.Message.Body.ExecutionPayload.BlockHash, nil
+	default:
+		return phase0.Hash32{}, errors.New("unknown version")
+	}
+}
+
+// Attestations returns the attestations of the beacon block.
+func (v *VersionedBlockRequest) Attestations() ([]*phase0.Attestation, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil {
+			return nil, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.Attestations, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil {
+			return nil, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.Attestations, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil || v.Deneb.SignedBlock.Message.Body == nil {
+			return nil, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlock.Message.Body.Attestations, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// Root returns the root of the beacon block.
+func (v *VersionedBlockRequest) Root() (phase0.Root, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil {
+			return phase0.Root{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.HashTreeRoot()
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil {
+			return phase0.Root{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.HashTreeRoot()
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil {
+			return phase0.Root{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlock.Message.HashTreeRoot()
+	default:
+		return phase0.Root{}, errors.New("unknown version")
+	}
+}
+
+// BodyRoot returns the body root of the beacon block.
+func (v *VersionedBlockRequest) BodyRoot() (phase0.Root, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil {
+			return phase0.Root{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.HashTreeRoot()
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil {
+			return phase0.Root{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.HashTreeRoot()
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil || v.Deneb.SignedBlock.Message.Body == nil {
+			return phase0.Root{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlock.Message.Body.HashTreeRoot()
+	default:
+		return phase0.Root{}, errors.New("unknown version")
+	}
+}
+
+// ParentRoot returns the parent root of the beacon block.
+func (v *VersionedBlockRequest) ParentRoot() (phase0.Root, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil {
+			return phase0.Root{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.ParentRoot, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil {
+			return phase0.Root{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.ParentRoot, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil {
+			return phase0.Root{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlock.Message.ParentRoot, nil
+	default:
+		return phase0.Root{}, errors.New("unknown version")
+	}
+}
+
+// StateRoot returns the state root of the beacon block.
+func (v *VersionedBlockRequest) StateRoot() (phase0.Root, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil {
+			return phase0.Root{}, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.StateRoot, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil {
+			return phase0.Root{}, errors.New("no capella block")
+		}
+		return v.Capella.Message.StateRoot, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil {
+			return phase0.Root{}, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlock.Message.StateRoot, nil
+	default:
+		return phase0.Root{}, errors.New("unknown version")
+	}
+}
+
+// AttesterSlashings returns the attester slashings of the beacon block.
+func (v *VersionedBlockRequest) AttesterSlashings() ([]*phase0.AttesterSlashing, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil {
+			return nil, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.AttesterSlashings, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil {
+			return nil, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.AttesterSlashings, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil || v.Deneb.SignedBlock.Message.Body == nil {
+			return nil, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlock.Message.Body.AttesterSlashings, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// ProposerSlashings returns the proposer slashings of the beacon block.
+func (v *VersionedBlockRequest) ProposerSlashings() ([]*phase0.ProposerSlashing, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil {
+			return nil, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.ProposerSlashings, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil {
+			return nil, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.ProposerSlashings, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil || v.Deneb.SignedBlock.Message.Body == nil {
+			return nil, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlock.Message.Body.ProposerSlashings, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// SyncAggregate returns the sync aggregate of the beacon block.
+func (v *VersionedBlockRequest) SyncAggregate() (*altair.SyncAggregate, error) {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil {
+			return nil, errors.New("no bellatrix block")
+		}
+		return v.Bellatrix.Message.Body.SyncAggregate, nil
+	case spec.DataVersionCapella:
+		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil {
+			return nil, errors.New("no capella block")
+		}
+		return v.Capella.Message.Body.SyncAggregate, nil
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil || v.Deneb.SignedBlock == nil || v.Deneb.SignedBlock.Message == nil || v.Deneb.SignedBlock.Message.Body == nil {
+			return nil, errors.New("no deneb block")
+		}
+		return v.Deneb.SignedBlock.Message.Body.SyncAggregate, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// String returns a string version of the structure.
+func (v *VersionedBlockRequest) String() string {
+	switch v.Version {
+	case spec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return ""
+		}
+		return v.Bellatrix.String()
+	case spec.DataVersionCapella:
+		if v.Capella == nil {
+			return ""
+		}
+		return v.Capella.String()
+	case spec.DataVersionDeneb:
+		if v.Deneb == nil {
+			return ""
+		}
+		return v.Deneb.String()
+	default:
+		return "unsupported version"
+	}
+}


### PR DESCRIPTION
The [publishBlindedBlockV2](https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/blocks/blinded_blocks.v2.yaml) and [publishBlockV2](https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/blocks/blocks.v2.yaml) uses `BlockContents` for Deneb as request bodies.

This adds a versioned struct to support the new endpoints. Open to moving the structs to a more suitable name / location e.g. under a /v2 folder.