### PR TITLE
Make initial connection check optional

### DIFF
--- a/http/parameters.go
+++ b/http/parameters.go
@@ -27,6 +27,7 @@ type parameters struct {
 	indexChunkSize  int
 	pubKeyChunkSize int
 	extraHeaders    map[string]string
+	connectionCheck bool
 }
 
 // Parameter is the interface for service parameters.
@@ -82,6 +83,13 @@ func WithExtraHeaders(headers map[string]string) Parameter {
 	})
 }
 
+// WithConnectionCheck enables/disables the client connection check.
+func WithConnectionCheck(connectionCheck bool) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.connectionCheck = connectionCheck
+	})
+}
+
 // parseAndCheckParameters parses and checks parameters to ensure that mandatory parameters are present and correct.
 func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	parameters := parameters{
@@ -90,6 +98,7 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 		indexChunkSize:  -1,
 		pubKeyChunkSize: -1,
 		extraHeaders:    make(map[string]string),
+		connectionCheck: true,
 	}
 	for _, p := range params {
 		if params != nil {

--- a/http/service.go
+++ b/http/service.go
@@ -114,9 +114,11 @@ func New(ctx context.Context, params ...Parameter) (eth2client.Service, error) {
 		extraHeaders:        parameters.extraHeaders,
 	}
 
-	// Fetch static values to confirm the connection is good.
-	if err := s.fetchStaticValues(ctx); err != nil {
-		return nil, errors.Wrap(err, "failed to confirm node connection")
+	if parameters.connectionCheck {
+		// Fetch static values to confirm the connection is good.
+		if err := s.fetchStaticValues(ctx); err != nil {
+			return nil, errors.Wrap(err, "failed to confirm node connection")
+		}
 	}
 
 	// Periodially refetch static values in case of client update.


### PR DESCRIPTION
I've added an additional parameter which can be used to disable the initial connection check:
```
client, err := http.New(ctx,
	http.WithAddress(endpoint),
	http.WithConnectionCheck(false),
)
```

This is useful when interacting with clients in early testnets, that might not fully follow the specs yet.
Even with these inconsistencies, I'd like to use these clients for other queries and would like to do this kind of error handling myself when necessary.
The forced initial check currently prevents these clients from being used via this library.

I've also made the DVT check optional and changed visibility of the optional code for max flexibility :)
This way, everyone can decide himself which checks are necessary if the built in defaults don't fit the individual needs.
The default behavior of this library is still the same, as the connection & DVT checks are enabled by default.