### PR TITLE
add blob_sidecar http handler

### DIFF
--- a/http/events.go
+++ b/http/events.go
@@ -167,6 +167,14 @@ func (s *Service) handleEvent(ctx context.Context, msg *sse.Event, handler clien
 			return
 		}
 		event.Data = payloadAttributesEvent
+	case "blob_sidecar":
+		blobSidecar := &api.BlobSidecarEvent{}
+		err := json.Unmarshal(msg.Data, blobSidecar)
+		if err != nil {
+			log.Error().Err(err).RawJSON("data", msg.Data).Msg("Failed to parse blob sidecar event")
+			return
+		}
+		event.Data = blobSidecar
 	case "":
 		// Used as keepalive.  Ignore.
 		return


### PR DESCRIPTION
Missed the http handler in https://github.com/attestantio/go-eth2-client/pull/79

Tested with deneb devnet 9 with teku publishing `blob_sidecars`