### PR TITLE
set sync_committee_size on start

### DIFF
--- a/spec/altair/syncaggregate.go
+++ b/spec/altair/syncaggregate.go
@@ -70,10 +70,10 @@ func (s *SyncAggregate) unpack(syncAggregateJSON *syncAggregateJSON) error {
 	if err != nil {
 		return errors.Wrap(err, "invalid value for sync committee bits")
 	}
-	if len(syncCommitteeBits) < syncCommitteeSize/8 {
+	if len(syncCommitteeBits) < SyncCommitteeSize/8 {
 		return errors.New("sync committee bits too short")
 	}
-	if len(syncCommitteeBits) > syncCommitteeSize/8 {
+	if len(syncCommitteeBits) > SyncCommitteeSize/8 {
 		return errors.New("sync committee bits too long")
 	}
 	s.SyncCommitteeBits = syncCommitteeBits

--- a/spec/altair/synccommittee.go
+++ b/spec/altair/synccommittee.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Altair constants.
-var syncCommitteeSize = 512
+// SyncCommitteeSize from spec.
+var SyncCommitteeSize = 512
 
 // SyncCommittee is the Ethereum 2 sync committee structure.
 type SyncCommittee struct {
@@ -70,10 +70,10 @@ func (s *SyncCommittee) UnmarshalJSON(input []byte) error {
 }
 
 func (s *SyncCommittee) unpack(syncCommitteeJSON *syncCommitteeJSON) error {
-	if len(syncCommitteeJSON.Pubkeys) != syncCommitteeSize {
+	if len(syncCommitteeJSON.Pubkeys) != SyncCommitteeSize {
 		return errors.New("incorrect length for public keys")
 	}
-	s.Pubkeys = make([]phase0.BLSPubKey, syncCommitteeSize)
+	s.Pubkeys = make([]phase0.BLSPubKey, SyncCommitteeSize)
 	for i := range syncCommitteeJSON.Pubkeys {
 		pubKey, err := hex.DecodeString(strings.TrimPrefix(syncCommitteeJSON.Pubkeys[i], "0x"))
 		if err != nil {


### PR DESCRIPTION
A potential fix for #87. I figured hooking in at New would be sufficient. The only issue I can think of would be that having a multi with different testnet configs could be an issue. (though I am not sure why someone would do this) I am open to other options. 