### PR TITLE
Fix parsing of ssz encoded blob sidecars

### DIFF
--- a/api/blobsidecars.go
+++ b/api/blobsidecars.go
@@ -26,7 +26,7 @@ type BlobSidecars struct {
 // UnmarshalSSZ ssz unmarshals the BlobSidecars object.
 // This is a hand-crafted function, as automatic generation does not support immediate arrays.
 func (b *BlobSidecars) UnmarshalSSZ(buf []byte) error {
-	num, err := ssz.DivideInt2(len(buf), 131256, 6)
+	num, err := ssz.DivideInt2(len(buf), 131928, 6)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func (b *BlobSidecars) UnmarshalSSZ(buf []byte) error {
 		if b.Sidecars[ii] == nil {
 			b.Sidecars[ii] = new(deneb.BlobSidecar)
 		}
-		if err = b.Sidecars[ii].UnmarshalSSZ(buf[ii*131256 : (ii+1)*131256]); err != nil {
+		if err = b.Sidecars[ii].UnmarshalSSZ(buf[ii*131928 : (ii+1)*131928]); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Parsing blob sidecars in SSZ format fails consistently for all clients on dencun-devnet-12.
The lib just returns the following error:
`failed to decode blob sidecars: xx`

There is a leftover from the previous spec version that is now causing this issue.
I've fixed it by just putting in the new blob sidecar SSZ size :)

