### PR TITLE
Opt-in to debug endpoint usage in `Validators`

### DIFF
--- a/api/validatorsopts.go
+++ b/api/validatorsopts.go
@@ -26,4 +26,6 @@ type ValidatorsOpts struct {
 	Indices []phase0.ValidatorIndex
 	// PubKeys is a list of validator public keys to restrict the returned values.  If no public keys are supplied then no filter will be applied.
 	PubKeys []phase0.BLSPubKey
+	// WithDebugEndpoints enables the use of debug endpoints for faster retrieval of large validator sets.
+	WithDebugEndpoints bool
 }

--- a/http/validators.go
+++ b/http/validators.go
@@ -128,14 +128,16 @@ func (s *Service) Validators(ctx context.Context,
 		return nil, errors.New("cannot specify both indices and public keys")
 	}
 
-	if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
-		// Request is for all validators; fetch from state.
-		return s.validatorsFromState(ctx, opts)
-	}
+	if opts.WithDebugEndpoints {
+		if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
+			// Request is for all validators; fetch from state.
+			return s.validatorsFromState(ctx, opts)
+		}
 
-	if len(opts.Indices) > indexChunkSizes["default"]*2 || len(opts.PubKeys) > pubKeyChunkSizes["default"]*2 {
-		// Request is for multiple pages of validators; fetch from state.
-		return s.validatorsFromState(ctx, opts)
+		if len(opts.Indices) > indexChunkSizes["default"]*2 || len(opts.PubKeys) > pubKeyChunkSizes["default"]*2 {
+			// Request is for multiple pages of validators; fetch from state.
+			return s.validatorsFromState(ctx, opts)
+		}
 	}
 
 	if len(opts.Indices) > s.indexChunkSize(ctx) || len(opts.PubKeys) > s.pubKeyChunkSize(ctx) {


### PR DESCRIPTION
The Beacon API spec says that the debug endpoints are:
> Set of endpoints to debug chain and shouldn't be exposed publicly.

For that reason, Prysm disables them by default, and since the `Validators` method leverages the debug endpoint to retrieve large validator sets, it's likely to fail in many setups.

I believe that go-eth2-client should either check that these endpoints are available as part of client creation, or allow the user to opt-in to using them.

This PR implements the latter, since I suspect that requesting the state at every connection may be too heavy.

@mcdee If you think opting-in at the client-level is preferable to method-level, I wouldn't mind refactoring that.