### PR TITLE
Unset `http.Client.Timeout` to obey `CommonOpts.Timeout`

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -85,7 +85,6 @@ func New(ctx context.Context, params ...Parameter) (eth2client.Service, error) {
 	}
 
 	client := &http.Client{
-		Timeout: parameters.timeout,
 		Transport: &http.Transport{
 			DialContext: (&net.Dialer{
 				Timeout:   parameters.timeout,


### PR DESCRIPTION
This PR leaves `http.Client.Timeout` unset so that `CommonOpts.Timeout` is obeyed when it's higher than the default timeout given to the go-eth2-client.

The timeout is set on every request to `CommonOpts.Timeout` or go-eth2-client's default timeout using `context.WithTimeout`, so not setting `http.Client.Timeout` should be safe.

Here's a scenario to reproduce the timeout issue:
```go
client, err := auto.New(
	ctx,
	auto.WithTimeout(5*time.Second),
)
if err != nil {
	panic(err)
}

validators, err := client.(eth2client.ValidatorsProvider).Validators(ctx, &api.ValidatorsOpts{
	State:   "head",
	Common:  api.CommonOpts{Timeout: 30 * time.Second},
})
if err != nil {
	panic(err) // times out after 5 seconds
}
```