### PR TITLE
Pass `CommonOpts` downstream in `Validators`

### DIFF
--- a/http/validators.go
+++ b/http/validators.go
@@ -189,7 +189,7 @@ func (s *Service) validatorsFromState(ctx context.Context,
 	*api.Response[map[phase0.ValidatorIndex]*apiv1.Validator],
 	error,
 ) {
-	stateResponse, err := s.BeaconState(ctx, &api.BeaconStateOpts{State: opts.State})
+	stateResponse, err := s.BeaconState(ctx, &api.BeaconStateOpts{State: opts.State, Common: opts.Common})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For your consideration. Personally I'm not sure if this is right, perhaps we do prefer to fallback to default timeout when deviating from the user's call? (`Validators` -> `BeaconState`)