### PR TITLE
Optional BeaconState usage in `Validators`

### DIFF
--- a/api/validatorsopts.go
+++ b/api/validatorsopts.go
@@ -26,7 +26,6 @@ type ValidatorsOpts struct {
 	Indices []phase0.ValidatorIndex
 	// PubKeys is a list of validator public keys to restrict the returned values.  If no public keys are supplied then no filter will be applied.
 	PubKeys []phase0.BLSPubKey
-	// WithBeaconState enables the use of the BeaconState endpoint for faster retrieval of large validator sets.
-	// This might increase memory usage during the request.
-	WithBeaconState bool
+	// WithoutBeaconState prevents the retrieval of BeaconState for large validator sets, which is often much faster but allocates much more memory.
+	WithoutBeaconState bool
 }

--- a/api/validatorsopts.go
+++ b/api/validatorsopts.go
@@ -26,4 +26,6 @@ type ValidatorsOpts struct {
 	Indices []phase0.ValidatorIndex
 	// PubKeys is a list of validator public keys to restrict the returned values.  If no public keys are supplied then no filter will be applied.
 	PubKeys []phase0.BLSPubKey
+	// WithDebugEndpoints enables the use of debug endpoints for faster retrieval of large validator sets.
+	WithDebugEndpoints bool
 }

--- a/api/validatorsopts.go
+++ b/api/validatorsopts.go
@@ -26,6 +26,7 @@ type ValidatorsOpts struct {
 	Indices []phase0.ValidatorIndex
 	// PubKeys is a list of validator public keys to restrict the returned values.  If no public keys are supplied then no filter will be applied.
 	PubKeys []phase0.BLSPubKey
-	// WithDebugEndpoints enables the use of debug endpoints for faster retrieval of large validator sets.
-	WithDebugEndpoints bool
+	// WithBeaconState enables the use of the BeaconState endpoint for faster retrieval of large validator sets.
+	// This might increase memory usage during the request.
+	WithBeaconState bool
 }

--- a/http/validators.go
+++ b/http/validators.go
@@ -128,7 +128,7 @@ func (s *Service) Validators(ctx context.Context,
 		return nil, errors.New("cannot specify both indices and public keys")
 	}
 
-	if opts.WithBeaconState {
+	if !opts.WithoutBeaconState {
 		if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
 			// Request is for all validators; fetch from state.
 			return s.validatorsFromState(ctx, opts)

--- a/http/validators.go
+++ b/http/validators.go
@@ -128,14 +128,16 @@ func (s *Service) Validators(ctx context.Context,
 		return nil, errors.New("cannot specify both indices and public keys")
 	}
 
-	if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
-		// Request is for all validators; fetch from state.
-		return s.validatorsFromState(ctx, opts)
-	}
+	if opts.WithDebugEndpoints {
+		if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
+			// Request is for all validators; fetch from state.
+			return s.validatorsFromState(ctx, opts)
+		}
 
-	if len(opts.Indices) > indexChunkSizes["default"]*2 || len(opts.PubKeys) > pubKeyChunkSizes["default"]*2 {
-		// Request is for multiple pages of validators; fetch from state.
-		return s.validatorsFromState(ctx, opts)
+		if len(opts.Indices) > indexChunkSizes["default"]*2 || len(opts.PubKeys) > pubKeyChunkSizes["default"]*2 {
+			// Request is for multiple pages of validators; fetch from state.
+			return s.validatorsFromState(ctx, opts)
+		}
 	}
 
 	if len(opts.Indices) > s.indexChunkSize(ctx) || len(opts.PubKeys) > s.pubKeyChunkSize(ctx) {

--- a/http/validators.go
+++ b/http/validators.go
@@ -128,7 +128,7 @@ func (s *Service) Validators(ctx context.Context,
 		return nil, errors.New("cannot specify both indices and public keys")
 	}
 
-	if opts.WithDebugEndpoints {
+	if opts.WithBeaconState {
 		if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
 			// Request is for all validators; fetch from state.
 			return s.validatorsFromState(ctx, opts)


### PR DESCRIPTION
Continuing from https://github.com/attestantio/go-eth2-client/pull/100, we've found that `BeaconState` calls in mainnet  allocate ~1170 MiB memory and require ~520 MiB memory from the OS to execute.

Our mainnet SSV nodes on Kubernetes now request up to 2 GB memory (in spikes), when they previously only needed up to 0.7 GB, yet they're still querying the same number of validators (~3000).

I'm not ruling out potential optimizations which can be done in `validatorsFromState`, yet I believe allowing go-eth2-client users to opt-out of `BeaconState` calls for slower operation in return for less memory usage is a reasonable trade-off nonetheless.

Reproducible:
```go
package main

import (
	"context"
	"fmt"
	"log"
	"runtime"
	"time"

	eth2client "github.com/attestantio/go-eth2-client"
	"github.com/attestantio/go-eth2-client/api"
	"github.com/attestantio/go-eth2-client/auto"
	"github.com/attestantio/go-eth2-client/spec/phase0"
	"github.com/rs/zerolog"
)

func main() {
	start := time.Now()
	ctx := context.Background()
	client, err := auto.New(
		ctx,
		auto.WithLogLevel(zerolog.DebugLevel),
		auto.WithAddress("http://localhost:5052"),
	)
	if err != nil {
		panic(err)
	}
	log.Printf("Connected within: %s", time.Since(start))

	start = time.Now()
	indices := []phase0.ValidatorIndex{}
	for i := 0; i < 3466; i++ {
		indices = append(indices, phase0.ValidatorIndex(i))
	}
	validators, err := client.(eth2client.ValidatorsProvider).Validators(ctx, &api.ValidatorsOpts{
		State:   "head",
		Indices: indices,
	})
	if err != nil {
		panic(err)
	}
	log.Printf("Validators: %d", len(validators.Data))
	log.Printf("Retrieved validators within: %s", time.Since(start))

	printMemUsg()
	runtime.GC()
	time.Sleep(10 * time.Second)
	printMemUsg()

	fmt.Println(len(validators.Data))
}

func printMemUsg() {
	var m runtime.MemStats
	runtime.ReadMemStats(&m)
	log.Printf("Alloc = %.2f MiB", bToMb(m.Alloc))
	log.Printf("TotalAlloc = %.2f MiB", bToMb(m.TotalAlloc))
	log.Printf("HeapIdle = %.2f MiB", bToMb(m.HeapIdle))
	log.Printf("HeapInuse = %.2f MiB", bToMb(m.HeapInuse))
	log.Printf("Sys = %.2f MiB", bToMb(m.Sys))
	fmt.Println()
}

func bToMb(b uint64) float64 {
	return float64(b) / 1024 / 1024
}
```

Output on a Linux machine with a mainnet Beacon node:
```
2024/02/04 09:27:20 Connected within: 7.059233ms
2024/02/04 09:27:22 Validators: 3466
2024/02/04 09:27:22 Retrieved validators within: 2.080944525s
2024/02/04 09:27:22 Alloc = 435.43 MiB
2024/02/04 09:27:22 TotalAlloc = 1170.45 MiB
2024/02/04 09:27:22 HeapIdle = 62.38 MiB
2024/02/04 09:27:22 HeapInuse = 436.65 MiB
2024/02/04 09:27:22 Sys = 519.52 MiB

2024/02/04 09:27:32 Alloc = 39.58 MiB
2024/02/04 09:27:32 TotalAlloc = 1170.45 MiB
2024/02/04 09:27:32 HeapIdle = 458.28 MiB
2024/02/04 09:27:32 HeapInuse = 40.75 MiB
2024/02/04 09:27:32 Sys = 519.77 MiB

3466
```