### PR TITLE
Enforce transaction size limits

### DIFF
--- a/spec/bellatrix/consts.go
+++ b/spec/bellatrix/consts.go
@@ -21,6 +21,12 @@ const FeeRecipientLength = 20
 // ExecutionAddressLength is the number of bytes in an execution address.
 const ExecutionAddressLength = 20
 
+// MaxBytesPerTransaction is the maximum number of bytes in a transaction.
+const MaxBytesPerTransaction = 1_073_741_824
+
+// MaxTransactionsPerPayload is the maximum number of transactions in a payload.
+const MaxTransactionsPerPayload = 1_048_576
+
 var maxBaseFeePerGas = new(big.Int).SetBytes([]byte{
 	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,

--- a/spec/bellatrix/executionpayload.go
+++ b/spec/bellatrix/executionpayload.go
@@ -305,16 +305,21 @@ func (e *ExecutionPayload) unpack(data *executionPayloadJSON) error {
 	if data.Transactions == nil {
 		return errors.New("transactions missing")
 	}
+	if len(data.Transactions) > MaxTransactionsPerPayload {
+		return errors.Wrap(err, "incorrect length for transactions")
+	}
 	transactions := make([]Transaction, len(data.Transactions))
 	for i := range data.Transactions {
 		if data.Transactions[i] == "" {
 			return errors.New("transaction missing")
 		}
-		tmp, err := hex.DecodeString(strings.TrimPrefix(data.Transactions[i], "0x"))
+		transactions[i], err = hex.DecodeString(strings.TrimPrefix(data.Transactions[i], "0x"))
 		if err != nil {
 			return errors.Wrap(err, "invalid value for transaction")
 		}
-		transactions[i] = Transaction(tmp)
+		if len(transactions[i]) > MaxBytesPerTransaction {
+			return errors.Wrap(err, "incorrect length for transaction")
+		}
 	}
 	e.Transactions = transactions
 

--- a/spec/capella/executionpayload.go
+++ b/spec/capella/executionpayload.go
@@ -310,16 +310,21 @@ func (e *ExecutionPayload) unpack(data *executionPayloadJSON) error {
 	if data.Transactions == nil {
 		return errors.New("transactions missing")
 	}
+	if len(data.Transactions) > bellatrix.MaxTransactionsPerPayload {
+		return errors.Wrap(err, "incorrect length for transactions")
+	}
 	transactions := make([]bellatrix.Transaction, len(data.Transactions))
 	for i := range data.Transactions {
 		if data.Transactions[i] == "" {
 			return errors.New("transaction missing")
 		}
-		tmp, err := hex.DecodeString(strings.TrimPrefix(data.Transactions[i], "0x"))
+		transactions[i], err = hex.DecodeString(strings.TrimPrefix(data.Transactions[i], "0x"))
 		if err != nil {
 			return errors.Wrap(err, "invalid value for transaction")
 		}
-		transactions[i] = bellatrix.Transaction(tmp)
+		if len(transactions[i]) > bellatrix.MaxBytesPerTransaction {
+			return errors.Wrap(err, "incorrect length for transaction")
+		}
 	}
 	e.Transactions = transactions
 

--- a/spec/deneb/executionpayload_json.go
+++ b/spec/deneb/executionpayload_json.go
@@ -205,6 +205,9 @@ func (e *ExecutionPayload) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(raw["transactions"], &transactions); err != nil {
 		return errors.Wrap(err, "transactions")
 	}
+	if len(transactions) > bellatrix.MaxTransactionsPerPayload {
+		return errors.Wrap(err, "incorrect length for transactions")
+	}
 	e.Transactions = make([]bellatrix.Transaction, len(transactions))
 	for i := range transactions {
 		if len(transactions[i]) == 0 ||
@@ -215,6 +218,9 @@ func (e *ExecutionPayload) UnmarshalJSON(input []byte) error {
 		e.Transactions[i] = make([]byte, (len(transactions[i])-4)/2)
 		if err := json.Unmarshal(transactions[i], &e.Transactions[i]); err != nil {
 			return errors.Wrapf(err, "transaction %d", i)
+		}
+		if len(e.Transactions[i]) > bellatrix.MaxBytesPerTransaction {
+			return errors.Wrapf(err, "incorrect length for transaction %d", i)
 		}
 	}
 


### PR DESCRIPTION
When JSON unmarshaling execution payload transactions, it was possible to have more than `MaxTransactionsPerPayload` transactions or individual transactions which were larger than `MaxBytesPerTransaction`.