### PR TITLE
Add an option for reduced memory usage

### DIFF
--- a/http/parameters.go
+++ b/http/parameters.go
@@ -118,9 +118,9 @@ func WithHooks(hooks *Hooks) Parameter {
 
 // WithReducedMemoryUsage reduces memory usage by disabling certain actions that may take significant amount of memory.
 // Enabling this may result in longer response times.
-func WithReducedMemoryUsage(reduceMemUsage bool) Parameter {
+func WithReducedMemoryUsage(reducedMemoryUsage bool) Parameter {
 	return parameterFunc(func(p *parameters) {
-		p.reducedMemoryUsage = reduceMemUsage
+		p.reducedMemoryUsage = reducedMemoryUsage
 	})
 }
 

--- a/http/parameters.go
+++ b/http/parameters.go
@@ -22,16 +22,17 @@ import (
 )
 
 type parameters struct {
-	logLevel          zerolog.Level
-	monitor           metrics.Service
-	address           string
-	timeout           time.Duration
-	indexChunkSize    int
-	pubKeyChunkSize   int
-	extraHeaders      map[string]string
-	enforceJSON       bool
-	allowDelayedStart bool
-	hooks             *Hooks
+	logLevel           zerolog.Level
+	monitor            metrics.Service
+	address            string
+	timeout            time.Duration
+	indexChunkSize     int
+	pubKeyChunkSize    int
+	extraHeaders       map[string]string
+	enforceJSON        bool
+	allowDelayedStart  bool
+	hooks              *Hooks
+	reducedMemoryUsage bool
 }
 
 // Parameter is the interface for service parameters.
@@ -112,6 +113,14 @@ func WithAllowDelayedStart(allowDelayedStart bool) Parameter {
 func WithHooks(hooks *Hooks) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.hooks = hooks
+	})
+}
+
+// WithReducedMemoryUsage reduces memory usage by disabling certain actions that may take significant amount of memory.
+// Enabling this may result in longer response times.
+func WithReducedMemoryUsage(reduceMemUsage bool) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.reducedMemoryUsage = reduceMemUsage
 	})
 }
 

--- a/http/service.go
+++ b/http/service.go
@@ -72,6 +72,7 @@ type Service struct {
 	connectionSynced         bool
 	enforceJSON              bool
 	connectedToDVTMiddleware bool
+	reducedMemoryUsage       bool
 }
 
 // New creates a new Ethereum 2 client service, connecting with a standard HTTP.
@@ -124,6 +125,7 @@ func New(ctx context.Context, params ...Parameter) (client.Service, error) {
 		enforceJSON:         parameters.enforceJSON,
 		pingSem:             semaphore.NewWeighted(1),
 		hooks:               parameters.hooks,
+		reducedMemoryUsage:  parameters.reducedMemoryUsage,
 	}
 
 	// Ping the client to see if it is ready to serve requests.

--- a/http/validators.go
+++ b/http/validators.go
@@ -119,12 +119,12 @@ func (s *Service) Validators(ctx context.Context,
 		return nil, errors.Join(errors.New("cannot specify both indices and public keys"), client.ErrInvalidOptions)
 	}
 
-	if !s.reducedMemoryUsage {
-		if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
-			// Request is for all validators; fetch from state.
-			return s.validatorsFromState(ctx, opts)
-		}
+	if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
+		// Request is for all validators; fetch from state.
+		return s.validatorsFromState(ctx, opts)
+	}
 
+	if !s.reducedMemoryUsage {
 		if len(opts.Indices) > s.indexChunkSize(ctx)*16 || len(opts.PubKeys) > s.pubKeyChunkSize(ctx)*16 {
 			// Request is for multiple pages of validators; fetch from state.
 			return s.validatorsFromState(ctx, opts)

--- a/http/validators.go
+++ b/http/validators.go
@@ -119,14 +119,16 @@ func (s *Service) Validators(ctx context.Context,
 		return nil, errors.Join(errors.New("cannot specify both indices and public keys"), client.ErrInvalidOptions)
 	}
 
-	if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
-		// Request is for all validators; fetch from state.
-		return s.validatorsFromState(ctx, opts)
-	}
+	if !s.reducedMemoryUsage {
+		if len(opts.Indices) == 0 && len(opts.PubKeys) == 0 {
+			// Request is for all validators; fetch from state.
+			return s.validatorsFromState(ctx, opts)
+		}
 
-	if len(opts.Indices) > s.indexChunkSize(ctx)*16 || len(opts.PubKeys) > s.pubKeyChunkSize(ctx)*16 {
-		// Request is for multiple pages of validators; fetch from state.
-		return s.validatorsFromState(ctx, opts)
+		if len(opts.Indices) > s.indexChunkSize(ctx)*16 || len(opts.PubKeys) > s.pubKeyChunkSize(ctx)*16 {
+			// Request is for multiple pages of validators; fetch from state.
+			return s.validatorsFromState(ctx, opts)
+		}
 	}
 
 	if len(opts.Indices) > s.indexChunkSize(ctx) || len(opts.PubKeys) > s.pubKeyChunkSize(ctx) {


### PR DESCRIPTION
This PR supersedes https://github.com/attestantio/go-eth2-client/pull/105 and uses the approach described in https://github.com/attestantio/go-eth2-client/pull/105#issuecomment-1937767726.

Changes:
- Add an option for HTTP Service that reduces memory usage by disabling certain actions that may take a significant amount of memory
- Optionally disable fetching validators from the state in the `Validators` call. The superseded PR has more details about this case