### PR TITLE
`(g *Gwei) UnmarshalJSON()` `panic` on malformed input

### DIFF
--- a/spec/phase0/gwei.go
+++ b/spec/phase0/gwei.go
@@ -30,6 +30,10 @@ func (g *Gwei) UnmarshalJSON(input []byte) error {
 		return errors.New("input missing")
 	}
 
+	if len(input) < 3 {
+		return errors.New("input malformed")
+	}
+
 	if !bytes.HasPrefix(input, []byte{'"'}) {
 		return errors.New("invalid prefix")
 	}

--- a/spec/phase0/gwei.go
+++ b/spec/phase0/gwei.go
@@ -29,11 +29,9 @@ func (g *Gwei) UnmarshalJSON(input []byte) error {
 	if len(input) == 0 {
 		return errors.New("input missing")
 	}
-
 	if len(input) < 3 {
 		return errors.New("input malformed")
 	}
-
 	if !bytes.HasPrefix(input, []byte{'"'}) {
 		return errors.New("invalid prefix")
 	}

--- a/spec/phase0/gwei_test.go
+++ b/spec/phase0/gwei_test.go
@@ -1,0 +1,73 @@
+// Copyright © 2020, 2021 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phase0_test
+
+// Create a test to verify gwei.unmarshalJSON
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+func TestGweiUnmarshalJSON(t *testing.T) {
+	// Test cases
+	tests := []struct {
+		name     string
+		input    []byte
+		expected phase0.Gwei
+		wantErr  bool
+	}{
+		{
+			name:     "Valid input 1000000000",
+			input:    []byte("\"1000000000\""),
+			expected: phase0.Gwei(1000000000),
+			wantErr:  false,
+		},
+
+		{
+			name:     "Valid input",
+			input:    []byte("\"1\""),
+			expected: phase0.Gwei(1),
+			wantErr:  false,
+		},
+
+		{
+			name:     "Invalid input text",
+			input:    []byte("not-a-number"),
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "Invalid input single quote",
+			input:    []byte("\""),
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	// Run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var g phase0.Gwei
+			err := g.UnmarshalJSON(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if g != tt.expected {
+				t.Errorf("UnmarshalJSON() got = %v, expected %v", g, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I am currently running [Nosy](https://github.com/infosecual/nosy) on a broad set of ethereum client dependencies. It found a few panics while fuzzing `go-eth2-client`.  This fixes an issues in `(g *Gwei) UnmarshalJSON()` where a `panic: runtime error: slice bounds out of range` is triggerable due to a malformed JSON token. 

Summary:

`(g *Gwei) UnmarshalJSON()` has a few checks upon entry to prevent issues but a `panic` can still be triggered if a single `"` character is provided. 

```go
	if len(input) == 0 {
		return errors.New("input missing")
	}
	if !bytes.HasPrefix(input, []byte{'"'}) {
		return errors.New("invalid prefix")
	}
	if !bytes.HasSuffix(input, []byte{'"'}) {
		return errors.New("invalid suffix")
	}
```
This bypasses the `len(input) == 0` check as well as the prefix and suffix checks, since the single `"` character matches.

The panic happens on the slice indexing shortly after:
```go
	val, err := strconv.ParseUint(string(input[1:len(input)-1]), 10, 64)
```

This PR adds a minimum length check for a valid entry to `(g *Gwei) UnmarshalJSON()` as well as a test for the malformed input. 