### PR TITLE
`(s *Slot) UnmarshalJSON()` `panic` on malformed input

### DIFF
--- a/spec/phase0/gwei_test.go
+++ b/spec/phase0/gwei_test.go
@@ -20,6 +20,58 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
+func TestSlotUnmarshalJSON(t *testing.T) {
+	// Test cases
+	tests := []struct {
+		name     string
+		input    []byte
+		expected phase0.Slot
+		wantErr  bool
+	}{
+		{
+			name:     "Valid input 100000",
+			input:    []byte("\"100000\""),
+			expected: phase0.Slot(100000),
+			wantErr:  false,
+		},
+
+		{
+			name:     "Valid input",
+			input:    []byte("\"1\""),
+			expected: phase0.Slot(1),
+			wantErr:  false,
+		},
+
+		{
+			name:     "Invalid input text",
+			input:    []byte("not-a-number"),
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "Invalid input single quote",
+			input:    []byte("\""),
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	// Run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s phase0.Slot
+			err := s.UnmarshalJSON(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if s != tt.expected {
+				t.Errorf("UnmarshalJSON() got = %v, expected %v", s, tt.expected)
+			}
+		})
+	}
+}
+
 func TestGweiUnmarshalJSON(t *testing.T) {
 	// Test cases
 	tests := []struct {

--- a/spec/phase0/slot.go
+++ b/spec/phase0/slot.go
@@ -29,7 +29,9 @@ func (s *Slot) UnmarshalJSON(input []byte) error {
 	if len(input) == 0 {
 		return errors.New("input missing")
 	}
-
+	if len(input) < 3 {
+		return errors.New("input malformed")
+	}
 	if !bytes.HasPrefix(input, []byte{'"'}) {
 		return errors.New("invalid prefix")
 	}


### PR DESCRIPTION
This PR is very similar to #122. This is a PR to fix a panic in a json unmarshal routine that was found via fuzzing. This PR adds a minimum length check for a valid entry to `(s *Slot) UnmarshalJSON()` as well as a test for the malformed input.