### PR TITLE
Remove deleted files from api/v1/deneb/generate.go

### DIFF
--- a/api/v1/deneb/generate.go
+++ b/api/v1/deneb/generate.go
@@ -17,4 +17,3 @@ package deneb
 //go:generate rm -f blindedbeaconblock_ssz.go blindedbeaconblockbody_ssz.go blockcontents_ssz.go signedblindedbeaconblock_ssz.go signedblockcontents_ssz.go
 //go:generate sszgen --include ../../../spec/phase0,../../../spec/altair,../../../spec/bellatrix,../../../spec/capella,../../../spec/deneb -path . --suffix ssz -objs BlindedBeaconBlock,BlindedBeaconBlockBody,BlockContents,SignedBlindedBeaconBlock,SignedBlockContents
 //go:generate goimports -w blindedbeaconblock_ssz.go blindedbeaconblockbody_ssz.go blockcontents_ssz.go signedblindedbeaconblock_ssz.go signedblockcontents_ssz.go
-

--- a/api/v1/deneb/generate.go
+++ b/api/v1/deneb/generate.go
@@ -14,6 +14,7 @@
 package deneb
 
 // Need to `go install github.com/ferranbt/fastssz/sszgen@latest` for this to work.
-//go:generate rm -f blindedbeaconblock_ssz.go blindedbeaconblockbody_ssz.go blindedblobsidecar_ssz.go blindedblockcontents_ssz.go blockcontents_ssz.go signedblindedbeaconblock_ssz.go signedblindedblockcontents_ssz.go signedblockcontents_ssz.go
-//go:generate sszgen --include ../../../spec/phase0,../../../spec/altair,../../../spec/bellatrix,../../../spec/capella,../../../spec/deneb -path . --suffix ssz -objs BlindedBeaconBlock,BlindedBeaconBlockBody,BlindedBlobSidecar,BlindedBlockContents,BlockContents,SignedBlindedBeaconBlock,SignedBlindedBlockContents,SignedBlockContents
-//go:generate goimports -w blindedbeaconblock_ssz.go blindedbeaconblockbody_ssz.go blindedblobsidecar_ssz.go blindedblockcontents_ssz.go blockcontents_ssz.go signedblindedbeaconblock_ssz.go signedblindedblockcontents_ssz.go,signedblockcontents_ssz.go
+//go:generate rm -f blindedbeaconblock_ssz.go blindedbeaconblockbody_ssz.go blockcontents_ssz.go signedblindedbeaconblock_ssz.go signedblockcontents_ssz.go
+//go:generate sszgen --include ../../../spec/phase0,../../../spec/altair,../../../spec/bellatrix,../../../spec/capella,../../../spec/deneb -path . --suffix ssz -objs BlindedBeaconBlock,BlindedBeaconBlockBody,BlockContents,SignedBlindedBeaconBlock,SignedBlockContents
+//go:generate goimports -w blindedbeaconblock_ssz.go blindedbeaconblockbody_ssz.go blockcontents_ssz.go signedblindedbeaconblock_ssz.go signedblockcontents_ssz.go
+


### PR DESCRIPTION
IIRC, these files existed at some point and we removed them. Looks like this file wasn't updated then.