### PR TITLE
Use electra.AttesterSlashing in api/v1/electra

### DIFF
--- a/api/v1/electra/blindedbeaconblockbody.go
+++ b/api/v1/electra/blindedbeaconblockbody.go
@@ -31,7 +31,7 @@ type BlindedBeaconBlockBody struct {
 	ETH1Data               *phase0.ETH1Data
 	Graffiti               [32]byte                      `ssz-size:"32"`
 	ProposerSlashings      []*phase0.ProposerSlashing    `ssz-max:"16"`
-	AttesterSlashings      []*phase0.AttesterSlashing    `ssz-max:"1"`
+	AttesterSlashings      []*electra.AttesterSlashing   `ssz-max:"1"`
 	Attestations           []*electra.Attestation        `ssz-max:"8"`
 	Deposits               []*phase0.Deposit             `ssz-max:"16"`
 	VoluntaryExits         []*phase0.SignedVoluntaryExit `ssz-max:"16"`

--- a/api/v1/electra/blindedbeaconblockbody_json.go
+++ b/api/v1/electra/blindedbeaconblockbody_json.go
@@ -34,7 +34,7 @@ type blindedBeaconBlockBodyJSON struct {
 	ETH1Data               *phase0.ETH1Data                      `json:"eth1_data"`
 	Graffiti               string                                `json:"graffiti"`
 	ProposerSlashings      []*phase0.ProposerSlashing            `json:"proposer_slashings"`
-	AttesterSlashings      []*phase0.AttesterSlashing            `json:"attester_slashings"`
+	AttesterSlashings      []*electra.AttesterSlashing           `json:"attester_slashings"`
 	Attestations           []*electra.Attestation                `json:"attestations"`
 	Deposits               []*phase0.Deposit                     `json:"deposits"`
 	VoluntaryExits         []*phase0.SignedVoluntaryExit         `json:"voluntary_exits"`

--- a/api/v1/electra/blindedbeaconblockbody_ssz.go
+++ b/api/v1/electra/blindedbeaconblockbody_ssz.go
@@ -304,10 +304,10 @@ func (b *BlindedBeaconBlockBody) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.AttesterSlashings = make([]*phase0.AttesterSlashing, num)
+		b.AttesterSlashings = make([]*electra.AttesterSlashing, num)
 		err = ssz.UnmarshalDynamic(buf, num, func(indx int, buf []byte) (err error) {
 			if b.AttesterSlashings[indx] == nil {
-				b.AttesterSlashings[indx] = new(phase0.AttesterSlashing)
+				b.AttesterSlashings[indx] = new(electra.AttesterSlashing)
 			}
 			if err = b.AttesterSlashings[indx].UnmarshalSSZ(buf); err != nil {
 				return err

--- a/api/v1/electra/blindedbeaconblockbody_yaml.go
+++ b/api/v1/electra/blindedbeaconblockbody_yaml.go
@@ -31,7 +31,7 @@ type blindedBeaconBlockBodyYAML struct {
 	ETH1Data               *phase0.ETH1Data                      `yaml:"eth1_data"`
 	Graffiti               string                                `yaml:"graffiti"`
 	ProposerSlashings      []*phase0.ProposerSlashing            `yaml:"proposer_slashings"`
-	AttesterSlashings      []*phase0.AttesterSlashing            `yaml:"attester_slashings"`
+	AttesterSlashings      []*electra.AttesterSlashing           `yaml:"attester_slashings"`
 	Attestations           []*electra.Attestation                `yaml:"attestations"`
 	Deposits               []*phase0.Deposit                     `yaml:"deposits"`
 	VoluntaryExits         []*phase0.SignedVoluntaryExit         `yaml:"voluntary_exits"`

--- a/api/versionedsignedblindedbeaconblock.go
+++ b/api/versionedsignedblindedbeaconblock.go
@@ -268,32 +268,64 @@ func (v *VersionedSignedBlindedBeaconBlock) StateRoot() (phase0.Root, error) {
 }
 
 // AttesterSlashings returns the attester slashings of the beacon block.
-func (v *VersionedSignedBlindedBeaconBlock) AttesterSlashings() ([]*phase0.AttesterSlashing, error) {
+func (v *VersionedSignedBlindedBeaconBlock) AttesterSlashings() ([]spec.VersionedAttesterSlashing, error) {
 	switch v.Version {
 	case spec.DataVersionBellatrix:
 		if v.Bellatrix == nil {
 			return nil, ErrDataMissing
 		}
 
-		return v.Bellatrix.Message.Body.AttesterSlashings, nil
+		versionedAttesterSlashings := make([]spec.VersionedAttesterSlashing, len(v.Bellatrix.Message.Body.AttesterSlashings))
+		for i, attesterSlashing := range v.Bellatrix.Message.Body.AttesterSlashings {
+			versionedAttesterSlashings[i] = spec.VersionedAttesterSlashing{
+				Version:   spec.DataVersionBellatrix,
+				Bellatrix: attesterSlashing,
+			}
+		}
+
+		return versionedAttesterSlashings, nil
 	case spec.DataVersionCapella:
 		if v.Capella == nil {
 			return nil, ErrDataMissing
 		}
 
-		return v.Capella.Message.Body.AttesterSlashings, nil
+		versionedAttesterSlashings := make([]spec.VersionedAttesterSlashing, len(v.Capella.Message.Body.AttesterSlashings))
+		for i, attesterSlashing := range v.Capella.Message.Body.AttesterSlashings {
+			versionedAttesterSlashings[i] = spec.VersionedAttesterSlashing{
+				Version: spec.DataVersionCapella,
+				Capella: attesterSlashing,
+			}
+		}
+
+		return versionedAttesterSlashings, nil
 	case spec.DataVersionDeneb:
 		if v.Deneb == nil {
 			return nil, ErrDataMissing
 		}
 
-		return v.Deneb.Message.Body.AttesterSlashings, nil
+		versionedAttesterSlashings := make([]spec.VersionedAttesterSlashing, len(v.Deneb.Message.Body.AttesterSlashings))
+		for i, attesterSlashing := range v.Deneb.Message.Body.AttesterSlashings {
+			versionedAttesterSlashings[i] = spec.VersionedAttesterSlashing{
+				Version: spec.DataVersionDeneb,
+				Deneb:   attesterSlashing,
+			}
+		}
+
+		return versionedAttesterSlashings, nil
 	case spec.DataVersionElectra:
 		if v.Electra == nil {
 			return nil, ErrDataMissing
 		}
 
-		return v.Electra.Message.Body.AttesterSlashings, nil
+		versionedAttesterSlashings := make([]spec.VersionedAttesterSlashing, len(v.Electra.Message.Body.AttesterSlashings))
+		for i, attesterSlashing := range v.Electra.Message.Body.AttesterSlashings {
+			versionedAttesterSlashings[i] = spec.VersionedAttesterSlashing{
+				Version: spec.DataVersionElectra,
+				Electra: attesterSlashing,
+			}
+		}
+
+		return versionedAttesterSlashings, nil
 	default:
 		return nil, ErrUnsupportedVersion
 	}

--- a/api/versionedsignedblindedproposal.go
+++ b/api/versionedsignedblindedproposal.go
@@ -276,20 +276,36 @@ func (v *VersionedSignedBlindedProposal) StateRoot() (phase0.Root, error) {
 }
 
 // AttesterSlashings returns the attester slashings of the blinded proposal.
-func (v *VersionedSignedBlindedProposal) AttesterSlashings() ([]*phase0.AttesterSlashing, error) {
+func (v *VersionedSignedBlindedProposal) AttesterSlashings() ([]spec.VersionedAttesterSlashing, error) {
 	switch v.Version {
 	case spec.DataVersionBellatrix:
 		if v.Bellatrix == nil {
 			return nil, ErrDataMissing
 		}
 
-		return v.Bellatrix.Message.Body.AttesterSlashings, nil
+		versionedAttesterSlashings := make([]spec.VersionedAttesterSlashing, len(v.Bellatrix.Message.Body.AttesterSlashings))
+		for i, attesterSlashing := range v.Bellatrix.Message.Body.AttesterSlashings {
+			versionedAttesterSlashings[i] = spec.VersionedAttesterSlashing{
+				Version:   spec.DataVersionBellatrix,
+				Bellatrix: attesterSlashing,
+			}
+		}
+
+		return versionedAttesterSlashings, nil
 	case spec.DataVersionCapella:
 		if v.Capella == nil {
 			return nil, ErrDataMissing
 		}
 
-		return v.Capella.Message.Body.AttesterSlashings, nil
+		versionedAttesterSlashings := make([]spec.VersionedAttesterSlashing, len(v.Capella.Message.Body.AttesterSlashings))
+		for i, attesterSlashing := range v.Capella.Message.Body.AttesterSlashings {
+			versionedAttesterSlashings[i] = spec.VersionedAttesterSlashing{
+				Version: spec.DataVersionCapella,
+				Capella: attesterSlashing,
+			}
+		}
+
+		return versionedAttesterSlashings, nil
 	case spec.DataVersionDeneb:
 		if v.Deneb == nil ||
 			v.Deneb.Message == nil ||
@@ -297,7 +313,15 @@ func (v *VersionedSignedBlindedProposal) AttesterSlashings() ([]*phase0.Attester
 			return nil, ErrDataMissing
 		}
 
-		return v.Deneb.Message.Body.AttesterSlashings, nil
+		versionedAttesterSlashings := make([]spec.VersionedAttesterSlashing, len(v.Deneb.Message.Body.AttesterSlashings))
+		for i, attesterSlashing := range v.Deneb.Message.Body.AttesterSlashings {
+			versionedAttesterSlashings[i] = spec.VersionedAttesterSlashing{
+				Version: spec.DataVersionDeneb,
+				Deneb:   attesterSlashing,
+			}
+		}
+
+		return versionedAttesterSlashings, nil
 	case spec.DataVersionElectra:
 		if v.Electra == nil ||
 			v.Electra.Message == nil ||
@@ -305,7 +329,15 @@ func (v *VersionedSignedBlindedProposal) AttesterSlashings() ([]*phase0.Attester
 			return nil, ErrDataMissing
 		}
 
-		return v.Electra.Message.Body.AttesterSlashings, nil
+		versionedAttesterSlashings := make([]spec.VersionedAttesterSlashing, len(v.Electra.Message.Body.AttesterSlashings))
+		for i, attesterSlashing := range v.Electra.Message.Body.AttesterSlashings {
+			versionedAttesterSlashings[i] = spec.VersionedAttesterSlashing{
+				Version: spec.DataVersionElectra,
+				Electra: attesterSlashing,
+			}
+		}
+
+		return versionedAttesterSlashings, nil
 	default:
 		return nil, ErrUnsupportedVersion
 	}


### PR DESCRIPTION
The structures in `api/v1/electra` were still using the old `AttesterSlashing` type.