### PR TITLE
Fix ssz-size for BlindedBeaconBlockBody

### DIFF
--- a/api/v1/electra/blindedbeaconblockbody.go
+++ b/api/v1/electra/blindedbeaconblockbody.go
@@ -39,7 +39,7 @@ type BlindedBeaconBlockBody struct {
 	ExecutionPayloadHeader *electra.ExecutionPayloadHeader
 	BLSToExecutionChanges  []*capella.SignedBLSToExecutionChange `ssz-max:"16"`
 	BlobKZGCommitments     []deneb.KZGCommitment                 `ssz-max:"4096" ssz-size:"?,48"`
-	Consolidations         []*electra.SignedConsolidation        `ssz-max:"16"`
+	Consolidations         []*electra.SignedConsolidation        `ssz-max:"1"`
 }
 
 // String returns a string version of the structure.

--- a/api/v1/electra/blindedbeaconblockbody_ssz.go
+++ b/api/v1/electra/blindedbeaconblockbody_ssz.go
@@ -422,7 +422,7 @@ func (b *BlindedBeaconBlockBody) UnmarshalSSZ(buf []byte) error {
 	// Field (12) 'Consolidations'
 	{
 		buf = tail[o12:]
-		num, err := ssz.DivideInt2(len(buf), 120, 16)
+		num, err := ssz.DivideInt2(len(buf), 120, 1)
 		if err != nil {
 			return err
 		}
@@ -641,7 +641,7 @@ func (b *BlindedBeaconBlockBody) HashTreeRootWith(hh ssz.HashWalker) (err error)
 				return
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, num, 16)
+		hh.MerkleizeWithMixin(subIndx, num, 1)
 	}
 
 	hh.Merkleize(indx)


### PR DESCRIPTION
Noticed this mistake when a signature check failed. Should have been 1.