### PR TITLE
fix: passing of timeouts in `chunkedValidators`

### DIFF
--- a/http/validators.go
+++ b/http/validators.go
@@ -314,7 +314,7 @@ func (s *Service) chunkedValidatorsByIndex(ctx context.Context,
 			chunkEnd = len(opts.Indices)
 		}
 		chunk := opts.Indices[chunkStart:chunkEnd]
-		chunkRes, err := s.Validators(ctx, &api.ValidatorsOpts{State: opts.State, Indices: chunk})
+		chunkRes, err := s.Validators(ctx, &api.ValidatorsOpts{State: opts.State, Indices: chunk, Common: opts.Common})
 		if err != nil {
 			return nil, errors.Join(errors.New("failed to obtain chunk"), err)
 		}
@@ -349,7 +349,7 @@ func (s *Service) chunkedValidatorsByPubkey(ctx context.Context,
 			chunkEnd = len(opts.PubKeys)
 		}
 		chunk := opts.PubKeys[chunkStart:chunkEnd]
-		chunkRes, err := s.Validators(ctx, &api.ValidatorsOpts{State: opts.State, PubKeys: chunk})
+		chunkRes, err := s.Validators(ctx, &api.ValidatorsOpts{State: opts.State, PubKeys: chunk, Common: opts.Common})
 		if err != nil {
 			return nil, errors.Join(errors.New("failed to obtain chunk"), err)
 		}


### PR DESCRIPTION
Timeouts weren't being passed to chunked validators request, causing deadline exceeds on big queries. 
All credits goes to @moshe-blox which is on vacation, just opening the PR to allow faster resolve on main branch.