### PR TITLE
Parse execution requests in BlindedBeaconBlockBody

### DIFF
--- a/api/v1/electra/blindedbeaconblockbody_json.go
+++ b/api/v1/electra/blindedbeaconblockbody_json.go
@@ -189,6 +189,10 @@ func (b *BlindedBeaconBlockBody) unpack(data *blindedBeaconBlockBodyJSON) error 
 		}
 		copy(b.BlobKZGCommitments[i][:], data)
 	}
+	if data.ExecutionRequests == nil {
+		return errors.New("execution requests missing")
+	}
+	b.ExecutionRequests = data.ExecutionRequests
 
 	return nil
 }


### PR DESCRIPTION
Noticed a little bug when integrating this with mev-boost. We forgot to parse these.