### PR TITLE
CheckConnectionState: option to consider node as not synced if el_offline is true

### DIFF
--- a/api/v1/syncstate.go
+++ b/api/v1/syncstate.go
@@ -32,6 +32,8 @@ type SyncState struct {
 	IsOptimistic bool
 	// IsSyncing is true if the node is syncing.
 	IsSyncing bool
+	// ELOffline is true if the node's EL client is offline.
+	ELOffline bool
 }
 
 // syncStateJSON is the spec representation of the struct.
@@ -40,6 +42,7 @@ type syncStateJSON struct {
 	SyncDistance string `json:"sync_distance"`
 	IsOptimistic bool   `json:"is_optimistic"`
 	IsSyncing    bool   `json:"is_syncing"`
+	ELOffline    bool   `json:"el_offline"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -49,6 +52,7 @@ func (s *SyncState) MarshalJSON() ([]byte, error) {
 		SyncDistance: fmt.Sprintf("%d", s.SyncDistance),
 		IsOptimistic: s.IsOptimistic,
 		IsSyncing:    s.IsSyncing,
+		ELOffline:    s.ELOffline,
 	})
 }
 
@@ -78,6 +82,7 @@ func (s *SyncState) UnmarshalJSON(input []byte) error {
 	s.SyncDistance = phase0.Slot(syncDistance)
 	s.IsOptimistic = syncStateJSON.IsOptimistic
 	s.IsSyncing = syncStateJSON.IsSyncing
+	s.ELOffline = syncStateJSON.ELOffline
 
 	return nil
 }

--- a/api/v1/syncstate_test.go
+++ b/api/v1/syncstate_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 
 	api "github.com/attestantio/go-eth2-client/api/v1"
-	require "github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSyncStateJSON(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSyncStateJSON(t *testing.T) {
 		},
 		{
 			name:  "Good",
-			input: []byte(`{"head_slot":"1","sync_distance":"2","is_optimistic":false,"is_syncing":true}`),
+			input: []byte(`{"head_slot":"1","sync_distance":"2","is_optimistic":false,"is_syncing":true,"el_offline":false}`),
 		},
 	}
 

--- a/http/parameters.go
+++ b/http/parameters.go
@@ -36,6 +36,7 @@ type parameters struct {
 	reducedMemoryUsage bool
 	customSpecSupport  bool
 	client             *http.Client
+	elConnectionCheck  bool
 }
 
 // Parameter is the interface for service parameters.
@@ -141,6 +142,13 @@ func WithCustomSpecSupport(customSpecSupport bool) Parameter {
 func WithHTTPClient(client *http.Client) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.client = client
+	})
+}
+
+// WithELConnectionCheck enables making sure EL is not offline to consider the client synced.
+func WithELConnectionCheck(elConnectionCheck bool) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.elConnectionCheck = elConnectionCheck
 	})
 }
 

--- a/http/service.go
+++ b/http/service.go
@@ -74,6 +74,7 @@ type Service struct {
 	connectedToDVTMiddleware bool
 	reducedMemoryUsage       bool
 	customSpecSupport        bool
+	elConnectionCheck        bool
 }
 
 // New creates a new Ethereum 2 client service, connecting with a standard HTTP.
@@ -131,6 +132,7 @@ func New(ctx context.Context, params ...Parameter) (client.Service, error) {
 		hooks:               parameters.hooks,
 		reducedMemoryUsage:  parameters.reducedMemoryUsage,
 		customSpecSupport:   parameters.customSpecSupport,
+		elConnectionCheck:   parameters.elConnectionCheck,
 	}
 
 	// Ping the client to see if it is ready to serve requests.
@@ -276,6 +278,9 @@ func (s *Service) CheckConnectionState(ctx context.Context) {
 		} else {
 			active = true
 			synced = (!response.Data.IsSyncing) || (response.Data.HeadSlot == 0 && response.Data.SyncDistance <= 1)
+			if s.elConnectionCheck && response.Data.ELOffline {
+				synced = false
+			}
 		}
 		s.pingSem.Release(1)
 	}

--- a/multi/parameters.go
+++ b/multi/parameters.go
@@ -32,6 +32,7 @@ type parameters struct {
 	enforceJSON       bool
 	allowDelayedStart bool
 	name              string
+	elConnectionCheck bool
 }
 
 // Parameter is the interface for service parameters.
@@ -105,6 +106,13 @@ func WithExtraHeaders(headers map[string]string) Parameter {
 func WithName(name string) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.name = name
+	})
+}
+
+// WithELConnectionCheck enables making sure EL is not offline to consider the client synced.
+func WithELConnectionCheck(elConnectionCheck bool) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.elConnectionCheck = elConnectionCheck
 	})
 }
 

--- a/multi/service.go
+++ b/multi/service.go
@@ -77,6 +77,7 @@ func New(ctx context.Context, params ...Parameter) (consensusclient.Service, err
 			http.WithEnforceJSON(parameters.enforceJSON),
 			http.WithExtraHeaders(parameters.extraHeaders),
 			http.WithAllowDelayedStart(true),
+			http.WithELConnectionCheck(parameters.elConnectionCheck),
 		)
 		if err != nil {
 			log.Error().Str("provider", address).Msg("Provider not present; dropping from rotation")


### PR DESCRIPTION
Closes https://github.com/attestantio/go-eth2-client/issues/171

The `multi` client doesn't switch clients if the current client's EL goes offline until the client sets `is_syncing` to `true`. It causes duty misses.

The PR adds a `WithELConnectionCheck` parameter to both `http` and `multi`, which makes the client consider a node as synced only if `el_offline` is `false`

It seems to work with Teku, Lighthouse, Nimbus correctly. It doesn't work with Prysm because of https://github.com/prysmaticlabs/prysm/issues/14226, its implementation of `el_offline` is incorrect, so the switch won't happen until it starts returning `"is_syncing":true`.