### PR TITLE
fix dynssz annotation for `electra.Attestation`

### DIFF
--- a/spec/electra/attestation.go
+++ b/spec/electra/attestation.go
@@ -31,7 +31,7 @@ import (
 //
 //nolint:tagalign
 type Attestation struct {
-	AggregationBits bitfield.Bitlist `ssz-max:"131072" dynssz-size:"MAX_VALIDATORS_PER_COMMITTEE*MAX_COMMITTEES_PER_SLOT"`
+	AggregationBits bitfield.Bitlist `ssz-max:"131072" dynssz-max:"MAX_VALIDATORS_PER_COMMITTEE*MAX_COMMITTEES_PER_SLOT"`
 	Data            *phase0.AttestationData
 	Signature       phase0.BLSSignature `ssz-size:"96"`
 	// bitfield.Bitvector64 is an 8 byte array so dynamic sizing doesn't make sense.


### PR DESCRIPTION
Parsing electra blocks with dynssz enabled currently fails for the BeaconBlockBody.Attestations field (size mismatch).

The problem is a wrong annotation in the Attestation container.
`dynssz-size` shouldn't be set here as there is no `ssz-size` too.
The intention of that tag was probably to calculate the `ssz-max` tag dynamically. 
The corresponding dynssz tag is called `dynssz-max`.

