### PR TITLE
feat: Add Validator Liveness support

### DIFF
--- a/api/v1/validatorliveness.go
+++ b/api/v1/validatorliveness.go
@@ -1,0 +1,62 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// ValidatorLiveness represents the observed liveness state of a validator.
+type ValidatorLiveness struct {
+	// Index is the validator index.
+	Index phase0.ValidatorIndex
+	// IsLive indicates whether the validator is live in the given epoch.
+	IsLive bool
+}
+
+// validatorLivenessJSON is the spec representation of the struct.
+type validatorLivenessJSON struct {
+	Index  string `json:"index"`
+	IsLive bool   `json:"is_live"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (v *ValidatorLiveness) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&validatorLivenessJSON{
+		Index:  fmt.Sprintf("%d", v.Index),
+		IsLive: v.IsLive,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (v *ValidatorLiveness) UnmarshalJSON(input []byte) error {
+	var validatorLivenessJSON validatorLivenessJSON
+	if err := json.Unmarshal(input, &validatorLivenessJSON); err != nil {
+		return errors.Wrap(err, "invalid JSON")
+	}
+
+	// Convert Index from string to phase0.ValidatorIndex
+	index, err := strconv.ParseUint(validatorLivenessJSON.Index, 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "invalid value for index")
+	}
+
+	v.Index = phase0.ValidatorIndex(index)
+	v.IsLive = validatorLivenessJSON.IsLive
+
+	return nil
+}
+
+// String returns a string version of the structure.
+func (v *ValidatorLiveness) String() string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("ERR: %v", err)
+	}
+
+	return string(data)
+}

--- a/api/v1/validatorliveness.go
+++ b/api/v1/validatorliveness.go
@@ -1,3 +1,16 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package v1
 
 import (

--- a/api/validatorlivenessopts.go
+++ b/api/validatorlivenessopts.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Attestant Limited.
+// Copyright © 2025 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -19,8 +19,8 @@ import "github.com/attestantio/go-eth2-client/spec/phase0"
 type ValidatorLivenessOpts struct {
 	Common CommonOpts
 
-	// Epoch is the epoch for which liveness is obtained.
+	// Epoch is the epoch for which the data is obtained.
 	Epoch phase0.Epoch
-	// ValidatorIndices is the indices of the validators for which liveness is obtained.
+	// Indices is a list of validators for which to obtain the duties.
 	Indices []phase0.ValidatorIndex
 }

--- a/api/validatorlivenessopts.go
+++ b/api/validatorlivenessopts.go
@@ -1,0 +1,26 @@
+// Copyright © 2023 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import "github.com/attestantio/go-eth2-client/spec/phase0"
+
+// ValidatorLivenessOpts are the options for obtaining validator liveness information.
+type ValidatorLivenessOpts struct {
+	Common CommonOpts
+
+	// Epoch is the epoch for which liveness is obtained.
+	Epoch phase0.Epoch
+	// ValidatorIndices is the indices of the validators for which liveness is obtained.
+	Indices []phase0.ValidatorIndex
+}

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -153,6 +153,7 @@ func TestInterfaces(t *testing.T) {
 	assert.Implements(t, (*client.SyncCommitteesProvider)(nil), s)
 	assert.Implements(t, (*client.SyncCommitteeSubscriptionsSubmitter)(nil), s)
 	assert.Implements(t, (*client.ValidatorBalancesProvider)(nil), s)
+	assert.Implements(t, (*client.ValidatorLivenessProvider)(nil), s)
 	assert.Implements(t, (*client.ValidatorsProvider)(nil), s)
 	assert.Implements(t, (*client.VoluntaryExitSubmitter)(nil), s)
 	assert.Implements(t, (*client.VoluntaryExitPoolProvider)(nil), s)

--- a/http/validatorliveness.go
+++ b/http/validatorliveness.go
@@ -1,3 +1,16 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package http
 
 import (
@@ -12,8 +25,14 @@ import (
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 )
 
-// ValidatorLiveness provides the liveness information for validators.
-func (s *Service) ValidatorLiveness(ctx context.Context, opts *api.ValidatorLivenessOpts) (*api.Response[[]*apiv1.ValidatorLiveness], error) {
+// ValidatorLiveness provides the liveness data to the given validators.
+func (s *Service) ValidatorLiveness(
+	ctx context.Context,
+	opts *api.ValidatorLivenessOpts,
+) (
+	*api.Response[[]*apiv1.ValidatorLiveness],
+	error,
+) {
 	if err := s.assertIsSynced(ctx); err != nil {
 		return nil, err
 	}
@@ -24,21 +43,21 @@ func (s *Service) ValidatorLiveness(ctx context.Context, opts *api.ValidatorLive
 		return nil, errors.Join(errors.New("no validator indices specified"), client.ErrInvalidOptions)
 	}
 
-	// Marshal the indices array into JSON
-	reqBody, err := json.Marshal(opts.Indices)
+	endpoint := fmt.Sprintf("/eth/v1/validator/liveness/%d", opts.Epoch)
+	query := ""
+
+	reqData, err := json.Marshal(opts.Indices)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal validator indices: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("/eth/v1/validator/liveness/%d", opts.Epoch)
-
 	httpResponse, err := s.post(ctx,
 		endpoint,
-		"",
-		&api.CommonOpts{},
-		bytes.NewReader(reqBody),
+		query,
+		&opts.Common,
+		bytes.NewReader(reqData),
 		ContentTypeJSON,
-		nil,
+		map[string]string{},
 	)
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to request validator liveness"), err)

--- a/http/validatorliveness.go
+++ b/http/validatorliveness.go
@@ -1,0 +1,56 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+)
+
+// ValidatorLiveness provides the liveness information for validators.
+func (s *Service) ValidatorLiveness(ctx context.Context, opts *api.ValidatorLivenessOpts) (*api.Response[[]*apiv1.ValidatorLiveness], error) {
+	if err := s.assertIsSynced(ctx); err != nil {
+		return nil, err
+	}
+	if opts == nil {
+		return nil, client.ErrNoOptions
+	}
+	if len(opts.Indices) == 0 {
+		return nil, errors.Join(errors.New("no validator indices specified"), client.ErrInvalidOptions)
+	}
+
+	// Marshal the indices array into JSON
+	reqBody, err := json.Marshal(opts.Indices)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal validator indices: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("/eth/v1/validator/liveness/%d", opts.Epoch)
+
+	httpResponse, err := s.post(ctx,
+		endpoint,
+		"",
+		&api.CommonOpts{},
+		bytes.NewReader(reqBody),
+		ContentTypeJSON,
+		nil,
+	)
+	if err != nil {
+		return nil, errors.Join(errors.New("failed to request validator liveness"), err)
+	}
+
+	data, metadata, err := decodeJSONResponse(bytes.NewReader(httpResponse.body), []*apiv1.ValidatorLiveness{})
+	if err != nil {
+		return nil, errors.Join(errors.New("failed to decode validator liveness response"), err)
+	}
+
+	return &api.Response[[]*apiv1.ValidatorLiveness]{
+		Data:     data,
+		Metadata: metadata,
+	}, nil
+}

--- a/http/validatorliveness_test.go
+++ b/http/validatorliveness_test.go
@@ -1,0 +1,98 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/http"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+func TestValidatorLiveness(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	service, err := http.New(ctx,
+		http.WithTimeout(timeout),
+		http.WithAddress(os.Getenv("HTTP_ADDRESS")),
+	)
+	require.NoError(t, err)
+
+	// Need to fetch current epoch for duties.
+	genesisResponse, err := service.(client.GenesisProvider).Genesis(ctx, &api.GenesisOpts{})
+	require.NoError(t, err)
+	slotDuration, err := service.(client.SlotDurationProvider).SlotDuration(ctx)
+	require.NoError(t, err)
+	slotsPerEpoch, err := service.(client.SlotsPerEpochProvider).SlotsPerEpoch(ctx)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		opts     *api.ValidatorLivenessOpts
+		expected []*apiv1.ValidatorLiveness
+		err      string
+		errCode  int
+	}{
+		{
+			name: "NilOpts",
+			err:  "no options specified",
+		},
+		{
+			name: "NoValidatorIndices",
+			opts: &api.ValidatorLivenessOpts{
+				Epoch:   phase0.Epoch(time.Since(genesisResponse.Data.GenesisTime).Seconds()) / phase0.Epoch(slotDuration.Seconds()) / phase0.Epoch(slotsPerEpoch),
+				Indices: []phase0.ValidatorIndex{},
+			},
+			err: "no validator indices specified",
+		},
+		{
+			name: "Good",
+			opts: &api.ValidatorLivenessOpts{
+				Epoch:   phase0.Epoch(time.Since(genesisResponse.Data.GenesisTime).Seconds()) / phase0.Epoch(slotDuration.Seconds()) / phase0.Epoch(slotsPerEpoch),
+				Indices: []phase0.ValidatorIndex{0, 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := service.(client.ValidatorLivenessProvider).ValidatorLiveness(ctx, test.opts)
+			switch {
+			case test.err != "":
+				require.ErrorContains(t, err, test.err)
+			case test.errCode != 0:
+				var apiErr *api.Error
+				if errors.As(err, &apiErr) {
+					require.Equal(t, test.errCode, apiErr.StatusCode)
+				}
+			default:
+				require.NoError(t, err)
+				require.NotNil(t, response)
+				if test.expected != nil {
+					require.Equal(t, test.expected, response.Data)
+				}
+			}
+		})
+	}
+}

--- a/mock/service.go
+++ b/mock/service.go
@@ -78,6 +78,7 @@ type Service struct {
 	SyncCommitteeDutiesFunc       func(context.Context, *api.SyncCommitteeDutiesOpts) (*api.Response[[]*apiv1.SyncCommitteeDuty], error)
 	SyncCommitteeRewardsFunc      func(context.Context, *api.SyncCommitteeRewardsOpts) (*api.Response[[]*apiv1.SyncCommitteeReward], error)
 	ValidatorBalancesFunc         func(context.Context, *api.ValidatorBalancesOpts) (*api.Response[map[phase0.ValidatorIndex]phase0.Gwei], error)
+	ValidatorLivenessFunc         func(context.Context, *api.ValidatorLivenessOpts) (*api.Response[[]*apiv1.ValidatorLiveness], error)
 	ValidatorsFunc                func(context.Context, *api.ValidatorsOpts) (*api.Response[map[phase0.ValidatorIndex]*apiv1.Validator], error)
 	VoluntaryExitPoolFunc         func(context.Context, *api.VoluntaryExitPoolOpts) (*api.Response[[]*phase0.SignedVoluntaryExit], error)
 }

--- a/mock/validatorliveness.go
+++ b/mock/validatorliveness.go
@@ -1,0 +1,45 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+)
+
+// ValidatorLiveness provides the liveness data to the given validators.
+func (s *Service) ValidatorLiveness(ctx context.Context,
+	opts *api.ValidatorLivenessOpts,
+) (
+	*api.Response[[]*apiv1.ValidatorLiveness],
+	error,
+) {
+	if s.ValidatorLivenessFunc != nil {
+		return s.ValidatorLivenessFunc(ctx, opts)
+	}
+
+	data := make([]*apiv1.ValidatorLiveness, len(opts.Indices))
+	for i := range opts.Indices {
+		data[i] = &apiv1.ValidatorLiveness{
+			Index: opts.Indices[i],
+		}
+	}
+
+	return &api.Response[[]*apiv1.ValidatorLiveness]{
+		Data:     data,
+		Metadata: make(map[string]any),
+	}, nil
+}

--- a/multi/service_test.go
+++ b/multi/service_test.go
@@ -17,12 +17,13 @@ import (
 	"context"
 	"testing"
 
-	client "github.com/attestantio/go-eth2-client"
-	"github.com/attestantio/go-eth2-client/mock"
-	"github.com/attestantio/go-eth2-client/multi"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/mock"
+	"github.com/attestantio/go-eth2-client/multi"
 )
 
 func TestService(t *testing.T) {
@@ -137,6 +138,7 @@ func TestInterfaces(t *testing.T) {
 	assert.Implements(t, (*client.SyncCommitteesProvider)(nil), s)
 	assert.Implements(t, (*client.SyncCommitteeSubscriptionsSubmitter)(nil), s)
 	assert.Implements(t, (*client.ValidatorBalancesProvider)(nil), s)
+	assert.Implements(t, (*client.ValidatorLivenessProvider)(nil), s)
 	assert.Implements(t, (*client.ValidatorsProvider)(nil), s)
 	assert.Implements(t, (*client.VoluntaryExitSubmitter)(nil), s)
 	assert.Implements(t, (*client.VoluntaryExitPoolProvider)(nil), s)

--- a/multi/service_test.go
+++ b/multi/service_test.go
@@ -17,13 +17,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/mock"
 	"github.com/attestantio/go-eth2-client/multi"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestService(t *testing.T) {

--- a/multi/validatorliveness.go
+++ b/multi/validatorliveness.go
@@ -1,42 +1,47 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package multi
 
 import (
 	"context"
-	"errors"
 
 	consensusclient "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 )
 
-// ValidatorLiveness provides the liveness information for validators across multiple clients.
+// ValidatorLiveness provides the liveness data to the given validators.
 func (s *Service) ValidatorLiveness(ctx context.Context,
 	opts *api.ValidatorLivenessOpts,
 ) (
 	*api.Response[[]*apiv1.ValidatorLiveness],
 	error,
 ) {
-	if opts == nil {
-		return nil, errors.New("no options provided for validator liveness")
-	}
-	if len(opts.Indices) == 0 {
-		return nil, errors.New("no validator indices specified")
-	}
-
 	res, err := s.doCall(ctx, func(ctx context.Context, client consensusclient.Service) (any, error) {
-		provider, ok := client.(consensusclient.ValidatorLivenessProvider)
-		if !ok {
-			return nil, errors.New("client does not support ValidatorLivenessProvider")
+		livenessData, err := client.(consensusclient.ValidatorLivenessProvider).ValidatorLiveness(ctx, opts)
+		if err != nil {
+			return nil, err
 		}
-		return provider.ValidatorLiveness(ctx, opts)
-	}, nil)
 
+		return livenessData, nil
+	}, nil)
 	if err != nil {
-		return nil, errors.Join(errors.New("failed to retrieve validator liveness"), err)
+		return nil, err
 	}
 
-	response, ok := res.(*api.Response[[]*apiv1.ValidatorLiveness])
-	if !ok {
+	response, isResponse := res.(*api.Response[[]*apiv1.ValidatorLiveness])
+	if !isResponse {
 		return nil, ErrIncorrectType
 	}
 

--- a/multi/validatorliveness.go
+++ b/multi/validatorliveness.go
@@ -1,0 +1,44 @@
+package multi
+
+import (
+	"context"
+	"errors"
+
+	consensusclient "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+)
+
+// ValidatorLiveness provides the liveness information for validators across multiple clients.
+func (s *Service) ValidatorLiveness(ctx context.Context,
+	opts *api.ValidatorLivenessOpts,
+) (
+	*api.Response[[]*apiv1.ValidatorLiveness],
+	error,
+) {
+	if opts == nil {
+		return nil, errors.New("no options provided for validator liveness")
+	}
+	if len(opts.Indices) == 0 {
+		return nil, errors.New("no validator indices specified")
+	}
+
+	res, err := s.doCall(ctx, func(ctx context.Context, client consensusclient.Service) (any, error) {
+		provider, ok := client.(consensusclient.ValidatorLivenessProvider)
+		if !ok {
+			return nil, errors.New("client does not support ValidatorLivenessProvider")
+		}
+		return provider.ValidatorLiveness(ctx, opts)
+	}, nil)
+
+	if err != nil {
+		return nil, errors.Join(errors.New("failed to retrieve validator liveness"), err)
+	}
+
+	response, ok := res.(*api.Response[[]*apiv1.ValidatorLiveness])
+	if !ok {
+		return nil, ErrIncorrectType
+	}
+
+	return response, nil
+}

--- a/multi/validatorliveness_test.go
+++ b/multi/validatorliveness_test.go
@@ -1,0 +1,61 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multi_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	consensusclient "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/mock"
+	"github.com/attestantio/go-eth2-client/multi"
+	"github.com/attestantio/go-eth2-client/testclients"
+)
+
+func TestValidatorLiveness(t *testing.T) {
+	ctx := context.Background()
+
+	client1, err := mock.New(ctx, mock.WithName("mock 1"))
+	require.NoError(t, err)
+	erroringClient1, err := testclients.NewErroring(ctx, 0.1, client1)
+	require.NoError(t, err)
+	client2, err := mock.New(ctx, mock.WithName("mock 2"))
+	require.NoError(t, err)
+	erroringClient2, err := testclients.NewErroring(ctx, 0.1, client2)
+	require.NoError(t, err)
+	client3, err := mock.New(ctx, mock.WithName("mock 3"))
+	require.NoError(t, err)
+
+	multiClient, err := multi.New(ctx,
+		multi.WithLogLevel(zerolog.Disabled),
+		multi.WithClients([]consensusclient.Service{
+			erroringClient1,
+			erroringClient2,
+			client3,
+		}),
+	)
+	require.NoError(t, err)
+
+	for i := 0; i < 128; i++ {
+		res, err := multiClient.(consensusclient.ValidatorLivenessProvider).ValidatorLiveness(ctx, &api.ValidatorLivenessOpts{})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	}
+	// At this point we expect mock 3 to be in active (unless probability hates us).
+	require.Equal(t, "mock 3", multiClient.Address())
+}

--- a/service.go
+++ b/service.go
@@ -505,9 +505,9 @@ type NodeSyncingProvider interface {
 	)
 }
 
-// ValidatorLivenessProvider is the interface for providing validator liveness state.
+// ValidatorLivenessProvider is the interface for providing validator liveness data.
 type ValidatorLivenessProvider interface {
-	// ValidatorLiveness provides the liveness state of validators in a given epoch.
+	// ValidatorLiveness provides the liveness data to the given validators.
 	ValidatorLiveness(ctx context.Context,
 		opts *api.ValidatorLivenessOpts,
 	) (

--- a/service.go
+++ b/service.go
@@ -505,6 +505,17 @@ type NodeSyncingProvider interface {
 	)
 }
 
+// ValidatorLivenessProvider is the interface for providing validator liveness state.
+type ValidatorLivenessProvider interface {
+	// ValidatorLiveness provides the liveness state of validators in a given epoch.
+	ValidatorLiveness(ctx context.Context,
+		opts *api.ValidatorLivenessOpts,
+	) (
+		*api.Response[[]*apiv1.ValidatorLiveness],
+		error,
+	)
+}
+
 // NodeVersionProvider is the interface for providing the node version.
 type NodeVersionProvider interface {
 	// NodeVersion returns a free-text string with the node version.

--- a/testclients/erroring.go
+++ b/testclients/erroring.go
@@ -965,3 +965,21 @@ func (s *Erroring) SyncCommitteeRewards(ctx context.Context,
 
 	return next.SyncCommitteeRewards(ctx, opts)
 }
+
+// ValidatorLiveness provides the liveness data to the given validators.
+func (s *Erroring) ValidatorLiveness(ctx context.Context,
+	opts *api.ValidatorLivenessOpts,
+) (
+	*api.Response[[]*apiv1.ValidatorLiveness],
+	error,
+) {
+	if err := s.maybeError(ctx); err != nil {
+		return nil, err
+	}
+	next, isNext := s.next.(consensusclient.ValidatorLivenessProvider)
+	if !isNext {
+		return nil, fmt.Errorf("%s@%s does not support this call", s.next.Name(), s.next.Address())
+	}
+
+	return next.ValidatorLiveness(ctx, opts)
+}

--- a/testclients/sleepy.go
+++ b/testclients/sleepy.go
@@ -689,3 +689,19 @@ func (s *Sleepy) SyncCommitteeRewards(ctx context.Context,
 
 	return next.SyncCommitteeRewards(ctx, opts)
 }
+
+// ValidatorLiveness provides the liveness data to the given validators.
+func (s *Sleepy) ValidatorLiveness(ctx context.Context,
+	opts *api.ValidatorLivenessOpts,
+) (
+	*api.Response[[]*apiv1.ValidatorLiveness],
+	error,
+) {
+	s.sleep(ctx)
+	next, isNext := s.next.(consensusclient.ValidatorLivenessProvider)
+	if !isNext {
+		return nil, errors.New("next does not support this call")
+	}
+
+	return next.ValidatorLiveness(ctx, opts)
+}


### PR DESCRIPTION
Add support for the POST `/eth/v1/validator/liveness/{epoch}` endpoint in the Beacon Node API.
This endpoint checks if a validator has been observed as live during a given epoch.