### PR TITLE
Increase size of indexed attestation indices.

### DIFF
--- a/spec/phase0/indexedattestation.go
+++ b/spec/phase0/indexedattestation.go
@@ -28,7 +28,7 @@ import (
 // IndexedAttestation provides a signed attestation with a list of attesting indices.
 type IndexedAttestation struct {
 	// Currently using primitives as sszgen does not handle []ValidatorIndex
-	AttestingIndices []uint64 `ssz-max:"2048"`
+	AttestingIndices []uint64 `ssz-max:"131072"`
 	Data             *AttestationData
 	Signature        BLSSignature `ssz-size:"96"`
 }


### PR DESCRIPTION
Electra increases the maximum size of indexed attestation indices, as per https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#attesterslashing

Although we could argue that this requires a new type, it's a simple increase in maximum size and so backwards-compatible with any prior legal indexed attestation.  So just increase the size and carry on with the existing type.