### PR TITLE
fix: add `dynssz-max` tag to capella withdrawals

### DIFF
--- a/util/capella/withdrawals.go
+++ b/util/capella/withdrawals.go
@@ -17,5 +17,5 @@ import "github.com/attestantio/go-eth2-client/spec/capella"
 
 // ExecutionPayloadWithdrawals provides information about withdrawals.
 type ExecutionPayloadWithdrawals struct {
-	Withdrawals []*capella.Withdrawal `ssz-max:"16"`
+	Withdrawals []*capella.Withdrawal `dynssz-max:"MAX_WITHDRAWALS_PER_PAYLOAD" ssz-max:"16"`
 }


### PR DESCRIPTION
This was already the case in capella's and deneb's `ExecutionPayload` structures, but missing here, unless I'm mistaken?