### PR TITLE
Update Consensus Block Value Handling

### DIFF
--- a/http/proposal.go
+++ b/http/proposal.go
@@ -350,7 +350,9 @@ func (*Service) populateProposalDataFromHeaders(response *api.Response[*api.Vers
 		case strings.EqualFold(k, "Eth-Consensus-Block-Value"):
 			var success bool
 			response.Data.ConsensusValue, success = new(big.Int).SetString(v, 10)
-			if !success {
+			// https://github.com/OffchainLabs/prysm/pull/14111
+			// Having the consensus block value is not critical to block production
+			if !success && v != "" {
 				return fmt.Errorf("proposal header Eth-Consensus-Block-Value %s not a valid integer", v)
 			}
 		}


### PR DESCRIPTION
•	Consensus Block Value: Now only returns an error if a non-empty value fails conversion, aligning with [PR14111](https://github.com/OffchainLabs/prysm/pull/14111) that it isn’t critical for block production.
•	Other Headers: No changes; the execution and blinded fields continue to be validated as before.

This update improves robustness by preventing errors when the consensus value is absent.