### PR TITLE
Update go-bitfield import path to OffchainLabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go get github.com/attestantio/go-eth2-client
 
   - [Lighthouse](https://github.com/sigp/lighthouse/) minimum version 2.0.0
   - [Nimbus](https://github.com/status-im/nimbus-eth2) minimum version 1.7.0
-  - [Prysm](https://github.com/prysmaticlabs/prysm) minimum version ?
+  - [Prysm](https://github.com/OffchainLabs/prysm) minimum version ?
   - [Teku](https://github.com/consensys/teku) minimum version 21.9.2
 
 ## Usage
@@ -51,7 +51,7 @@ package main
 import (
     "context"
     "fmt"
-    
+
     eth2client "github.com/attestantio/go-eth2-client"
     "github.com/attestantio/go-eth2-client/api"
     "github.com/attestantio/go-eth2-client/http"
@@ -70,9 +70,9 @@ func main() {
     if err != nil {
         panic(err)
     }
-    
+
     fmt.Printf("Connected to %s\n", client.Name())
-    
+
     // Client functions have their own interfaces.  Not all functions are
     // supported by all clients, so checks should be made for each function when
     // casting the service to the relevant interface.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.0
 toolchain go1.23.2
 
 require (
+	github.com/OffchainLabs/go-bitfield v0.0.0-20250408211841-ad7364de91a5
 	github.com/ferranbt/fastssz v0.1.4
 	github.com/goccy/go-yaml v1.9.2
 	github.com/golang/snappy v0.0.4
@@ -14,7 +15,6 @@ require (
 	github.com/pk910/dynamic-ssz v0.0.4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/rs/zerolog v1.32.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/OffchainLabs/go-bitfield v0.0.0-20250408211841-ad7364de91a5 h1:25NqnaOHAsyeeq5PAAKVXdkmTbmAkd8aL8h5sgX1Vys=
+github.com/OffchainLabs/go-bitfield v0.0.0-20250408211841-ad7364de91a5/go.mod h1:6TZI4FU6zT8x6ZfWa1J8YQ2NgW0wLV/W3fHRca8ISBo=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -83,8 +85,6 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
-github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15 h1:lC8kiphgdOBTcbTvo8MwkvpKjO0SlAgjv4xIK5FGJ94=
-github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15/go.mod h1:8svFBIKKu31YriBG/pNizo9N0Jr9i5PQ+dFkxWg3x5k=
 github.com/prysmaticlabs/gohashtree v0.0.4-beta h1:H/EbCuXPeTV3lpKeXGPpEV9gsUpkqOOVnWapUyeWro4=
 github.com/prysmaticlabs/gohashtree v0.0.4-beta/go.mod h1:BFdtALS+Ffhg3lGQIHv9HDWuHS8cTvHZzrHWxwOtGOs=
 github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=

--- a/http/submitattestations_test.go
+++ b/http/submitattestations_test.go
@@ -15,17 +15,18 @@ package http_test
 
 import (
 	"context"
-	"github.com/attestantio/go-eth2-client/spec"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec"
+
+	"github.com/OffchainLabs/go-bitfield"
 	client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/http"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/require"
 )
 

--- a/mock/blindedproposal.go
+++ b/mock/blindedproposal.go
@@ -16,11 +16,11 @@ package mock
 import (
 	"context"
 
+	"github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/api"
 	apiv1bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/prysmaticlabs/go-bitfield"
 )
 
 // BlindedProposal fetches a blinded proposal for signing.

--- a/mock/proposal.go
+++ b/mock/proposal.go
@@ -16,10 +16,10 @@ package mock
 import (
 	"context"
 
+	"github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/prysmaticlabs/go-bitfield"
 )
 
 // Proposal fetches a proposal for signing.

--- a/mock/synccommitteecontributionprovider.go
+++ b/mock/synccommitteecontributionprovider.go
@@ -16,10 +16,10 @@ package mock
 import (
 	"context"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // SyncCommitteeContribution provides a sync committee contribution.

--- a/spec/altair/beaconstate.go
+++ b/spec/altair/beaconstate.go
@@ -21,10 +21,10 @@ import (
 	"strconv"
 	"strings"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // BeaconState represents a beacon state.

--- a/spec/altair/syncaggregate.go
+++ b/spec/altair/syncaggregate.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"strings"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // SyncAggregate is the Ethereum 2 sync aggregate structure.

--- a/spec/altair/synccommitteecontribution.go
+++ b/spec/altair/synccommitteecontribution.go
@@ -21,10 +21,10 @@ import (
 	"strconv"
 	"strings"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // SyncCommitteeContribution is the Ethereum 2 sync committee contribution structure.

--- a/spec/bellatrix/beaconstate.go
+++ b/spec/bellatrix/beaconstate.go
@@ -21,11 +21,11 @@ import (
 	"strconv"
 	"strings"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // BeaconState represents a beacon state.

--- a/spec/capella/beaconstate.go
+++ b/spec/capella/beaconstate.go
@@ -16,10 +16,10 @@ package capella
 import (
 	"fmt"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/goccy/go-yaml"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // BeaconState represents a beacon state.

--- a/spec/deneb/beaconstate.go
+++ b/spec/deneb/beaconstate.go
@@ -16,11 +16,11 @@ package deneb
 import (
 	"fmt"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/goccy/go-yaml"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // BeaconState represents a beacon state.

--- a/spec/electra/attestation.go
+++ b/spec/electra/attestation.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // Attestation is the Ethereum 2 attestation structure.

--- a/spec/electra/attestation_test.go
+++ b/spec/electra/attestation_test.go
@@ -14,12 +14,13 @@
 package electra_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/spec/electra/beaconstate.go
+++ b/spec/electra/beaconstate.go
@@ -16,12 +16,12 @@ package electra
 import (
 	"fmt"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/goccy/go-yaml"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // BeaconState represents a beacon state.

--- a/spec/phase0/attestation.go
+++ b/spec/phase0/attestation.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"strings"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // Attestation is the Ethereum 2 attestation structure.

--- a/spec/phase0/beaconstate.go
+++ b/spec/phase0/beaconstate.go
@@ -21,9 +21,9 @@ import (
 	"strconv"
 	"strings"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // BeaconState represents a beacon state.

--- a/spec/phase0/pendingattestation.go
+++ b/spec/phase0/pendingattestation.go
@@ -21,9 +21,9 @@ import (
 	"strconv"
 	"strings"
 
+	bitfield "github.com/OffchainLabs/go-bitfield"
 	"github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
 // PendingAttestation is the Ethereum 2 pending attestation structure.

--- a/spec/versionedattestation.go
+++ b/spec/versionedattestation.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/OffchainLabs/go-bitfield"
 
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"

--- a/spec/versionedattestation_test.go
+++ b/spec/versionedattestation_test.go
@@ -14,13 +14,14 @@
 package spec_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/OffchainLabs/go-bitfield"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
After Prysm team joined Offchain Labs they moved their repo into the Offchain Labs org.
https://github.com/OffchainLabs/go-bitfield/pull/63