### PR TITLE
Add ValidateMetadata hook to CommonOpts for metadata validation

### DIFF
--- a/api/commonopts.go
+++ b/api/commonopts.go
@@ -20,4 +20,8 @@ type CommonOpts struct {
 	// Timeout is a specific timeout for this call.
 	// If 0 then the default timeout is used.
 	Timeout time.Duration
+
+	// ValidateMetadata is an optional callback
+	// to validate the metadata returned by an API call.
+	ValidateMetadata func(map[string]any) error
 }

--- a/http/aggregateattestation.go
+++ b/http/aggregateattestation.go
@@ -56,6 +56,12 @@ func (s *Service) AggregateAttestation(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	// Confirm the attestation is for the requested slot.
 	attestationData, err := data.Data()
 	if err != nil {

--- a/http/attestationdata.go
+++ b/http/attestationdata.go
@@ -65,6 +65,12 @@ func (s *Service) attestationDataFromJSON(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := s.verifyAttestationData(ctx, opts, &data); err != nil {
 		return nil, err
 	}

--- a/http/attestationpool.go
+++ b/http/attestationpool.go
@@ -74,6 +74,12 @@ func (*Service) attestationPoolFromJSON(_ context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := verifyAttestationPool(opts, data); err != nil {
 		return nil, err
 	}

--- a/http/attestationrewards.go
+++ b/http/attestationrewards.go
@@ -72,6 +72,12 @@ func (s *Service) AttestationRewards(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*apiv1.AttestationRewards]{
 		Data:     &data,
 		Metadata: metadata,

--- a/http/attesterduties.go
+++ b/http/attesterduties.go
@@ -80,6 +80,12 @@ func (s *Service) AttesterDuties(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	// Confirm that duties are for the requested epoch.
 	slotsPerEpoch, err := s.SlotsPerEpoch(ctx)
 	if err != nil {

--- a/http/beaconblockheader.go
+++ b/http/beaconblockheader.go
@@ -49,6 +49,12 @@ func (s *Service) BeaconBlockHeader(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	if !isBlockHeaderResponseValid(&data) {
 		return nil, errors.New("invalid beacon block header")
 	}

--- a/http/beaconblockroot.go
+++ b/http/beaconblockroot.go
@@ -56,6 +56,12 @@ func (s *Service) BeaconBlockRoot(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*phase0.Root]{
 		Data:     &data.Root,
 		Metadata: metadata,

--- a/http/beaconcommittees.go
+++ b/http/beaconcommittees.go
@@ -57,6 +57,12 @@ func (s *Service) BeaconCommittees(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[[]*apiv1.BeaconCommittee]{
 		Metadata: metadata,
 		Data:     data,

--- a/http/beaconstaterandao.go
+++ b/http/beaconstaterandao.go
@@ -51,6 +51,12 @@ func (s *Service) BeaconStateRandao(ctx context.Context, opts *api.BeaconStateRa
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*phase0.Root]{
 		Data:     &data.Randao,
 		Metadata: metadata,

--- a/http/beaconstateroot.go
+++ b/http/beaconstateroot.go
@@ -51,6 +51,12 @@ func (s *Service) BeaconStateRoot(ctx context.Context, opts *api.BeaconStateRoot
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*phase0.Root]{
 		Data:     &data.Root,
 		Metadata: metadata,

--- a/http/blockrewards.go
+++ b/http/blockrewards.go
@@ -58,6 +58,12 @@ func (s *Service) BlockRewards(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*apiv1.BlockRewards]{
 		Data:     data,
 		Metadata: metadata,

--- a/http/depositcontract.go
+++ b/http/depositcontract.go
@@ -69,6 +69,12 @@ func (s *Service) DepositContract(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	s.depositContract = &data
 
 	return &api.Response[*apiv1.DepositContract]{

--- a/http/finality.go
+++ b/http/finality.go
@@ -48,6 +48,12 @@ func (s *Service) Finality(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*apiv1.Finality]{
 		Metadata: metadata,
 		Data:     data,

--- a/http/fork.go
+++ b/http/fork.go
@@ -52,6 +52,12 @@ func (s *Service) Fork(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*phase0.Fork]{
 		Metadata: metadata,
 		Data:     &data,

--- a/http/forkschedule.go
+++ b/http/forkschedule.go
@@ -68,6 +68,13 @@ func (s *Service) ForkSchedule(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	s.forkSchedule = data
 
 	return &api.Response[[]*phase0.Fork]{

--- a/http/nodepeers.go
+++ b/http/nodepeers.go
@@ -59,6 +59,12 @@ func (s *Service) NodePeers(ctx context.Context, opts *api.NodePeersOpts) (*api.
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(meta); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[[]*apiv1.Peer]{
 		Data:     data,
 		Metadata: meta,

--- a/http/nodesyncing.go
+++ b/http/nodesyncing.go
@@ -41,6 +41,12 @@ func (s *Service) NodeSyncing(ctx context.Context, opts *api.NodeSyncingOpts) (*
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*apiv1.SyncState]{
 		Data:     data,
 		Metadata: metadata,

--- a/http/nodeversion.go
+++ b/http/nodeversion.go
@@ -70,6 +70,12 @@ func (s *Service) NodeVersion(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	s.nodeVersion = data.Version
 
 	return &api.Response[string]{

--- a/http/pendingdeposits.go
+++ b/http/pendingdeposits.go
@@ -58,6 +58,12 @@ func (s *Service) PendingDeposits(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[[]*electra.PendingDeposit]{
 		Data:     data,
 		Metadata: metadata,

--- a/http/proposerduties.go
+++ b/http/proposerduties.go
@@ -50,6 +50,12 @@ func (s *Service) ProposerDuties(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	// Confirm that duties are for the requested epoch.
 	slotsPerEpoch, err := s.SlotsPerEpoch(ctx)
 	if err != nil {

--- a/http/spec.go
+++ b/http/spec.go
@@ -73,6 +73,12 @@ func (s *Service) Spec(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	config := make(map[string]any)
 	for k, v := range data {
 		// Handle domains.

--- a/http/synccommittee.go
+++ b/http/synccommittee.go
@@ -57,6 +57,12 @@ func (s *Service) SyncCommittee(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[*apiv1.SyncCommittee]{
 		Metadata: metadata,
 		Data:     &data,

--- a/http/synccommitteecontribution.go
+++ b/http/synccommitteecontribution.go
@@ -57,6 +57,12 @@ func (s *Service) SyncCommitteeContribution(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	// Confirm the contribution is for the requested slot.
 	if data.Slot != opts.Slot {
 		return nil, errors.Join(

--- a/http/synccommitteeduties.go
+++ b/http/synccommitteeduties.go
@@ -79,6 +79,12 @@ func (s *Service) SyncCommitteeDuties(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[[]*apiv1.SyncCommitteeDuty]{
 		Metadata: metadata,
 		Data:     data,

--- a/http/synccommitteerewards.go
+++ b/http/synccommitteerewards.go
@@ -75,6 +75,12 @@ func (s *Service) SyncCommitteeRewards(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[[]*apiv1.SyncCommitteeReward]{
 		Data:     data,
 		Metadata: metadata,

--- a/http/validatorliveness.go
+++ b/http/validatorliveness.go
@@ -68,6 +68,12 @@ func (s *Service) ValidatorLiveness(
 		return nil, errors.Join(errors.New("failed to decode validator liveness response"), err)
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	return &api.Response[[]*apiv1.ValidatorLiveness]{
 		Data:     data,
 		Metadata: metadata,

--- a/http/validators.go
+++ b/http/validators.go
@@ -91,6 +91,12 @@ func (s *Service) Validators(ctx context.Context,
 		return nil, err
 	}
 
+	if opts.Common.ValidateMetadata != nil {
+		if err = opts.Common.ValidateMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
 	// Data is returned as an array but we want it as a map.
 	mapData := make(map[phase0.ValidatorIndex]*apiv1.Validator)
 	for _, validator := range data {


### PR DESCRIPTION
# Add ValidateMetadata hook to CommonOpts

## Summary

This PR introduces a new, optional `ValidateMetadata` hook to the `CommonOpts` struct in **go-eth2-client**. This function receives a `map[string]any` containing the metadata returned by a beacon node (for example, the `dependent_root` in validator duties responses) and returns an error if the metadata should be considered invalid. If provided, the client library will invoke this hook on all API calls that return metadata *before* accepting the result. This allows applications to reject stale or inconsistent data from individual nodes before it is used.

## Motivation

In multi-node beacon chain setups (e.g. using a pool of beacon clients for high availability), a synchronization issue can occur: one node may respond faster but with outdated state, leading to incorrect metadata. For example, **after subscribing to head events, a call to [`GET /eth/v1/validator/duties/proposer/{epoch}`](https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDuties) could return results from a client that isn’t yet fully synced**. Its `dependent_root` (the block root that the response depends on) might be behind the latest head, resulting in inconsistent or stale duties being returned.

The `ValidateMetadata` hook addresses this by giving users a way to programmatically inspect and validate the returned metadata before it is accepted. If the hook returns an error, the library treats that response as invalid, allowing the caller to **retry the request against another client**. This mechanism is particularly useful for ensuring that all clients in a multi-instance configuration return coherent and up-to-date metadata.

## Implementation

* A new field `ValidateMetadata func(map[string]any) error` is added to the `CommonOpts` struct. It is **optional**; if it is `nil`, no validation is performed (preserving the existing behavior).
* All relevant API handlers that process metadata now invoke this hook. For example, in the proposer duties provider (and similarly in attester duties, sync committee duties, etc.), after unmarshalling the response, the code does:

  ```go
  if opts.Common.ValidateMetadata != nil {
      if err := opts.Common.ValidateMetadata(metadata); err != nil {
          return nil, err
      }
  }
  ```

  This ensures that we only return a result if the metadata passes validation.
* No existing endpoints or return types are changed. The hook is simply an additional layer on top of the response processing.

## Benefits

* **Improved Consistency:** Users can ensure critical metadata fields (such as `dependent_root`, `execution_optimistic`, etc.) meet their expectations. This avoids using stale or invalid metadata for validator duties or other operations.
* **General-Purpose Hook:** The `ValidateMetadata` function can contain any custom logic. For instance, it could verify chain IDs, check block roots, validate timestamps, or enforce other application-specific rules on the metadata.
* **Enhanced Multi-Client Handling:** In multi-node setups, this feature helps filter out undesirable responses (from lagging or misbehaving nodes) without modifying the library itself. Callers can automatically fall back to another client if validation fails.
* **Backward-Compatible:** Because the hook is optional and disabled by default, existing users see no change in behavior unless they opt into it.

## Backward Compatibility

* The new `ValidateMetadata` field is optional and defaults to `nil`. Existing code that does not use this field will operate exactly as before.
* No existing APIs, function signatures, or response formats are changed or removed.
* Because this feature is opt-in, upgrading to include this change is safe for existing users.
