### PR TITLE
remove not nil check for payloadAttributes WithdrawalRequests and ConsolidationRequests

### DIFF
--- a/api/v1/payloadattributesevent.go
+++ b/api/v1/payloadattributesevent.go
@@ -417,9 +417,6 @@ func (p *PayloadAttributesV4) unpack(data *payloadAttributesV4JSON) error {
 	}
 	p.DepositRequests = data.DepositRequests
 
-	if data.WithdrawalRequests == nil {
-		return errors.New("payload attributes withdraw requests missing")
-	}
 	for i := range data.WithdrawalRequests {
 		if data.WithdrawalRequests[i] == nil {
 			return fmt.Errorf("withdraw requests entry %d missing", i)


### PR DESCRIPTION
I'm also not sure if Prysm and other clients support these fields: https://github.com/attestantio/go-eth2-client/issues/237

https://github.com/OffchainLabs/prysm/blob/0a48fafc710bd4453d71fe44d298c9f24a763787/beacon-chain/rpc/eth/events/events.go#L806C6-L846