### PR TITLE
fix: fulu - remove versionedHashes from data_column_sidecar events

### DIFF
--- a/api/v1/datacolumnsidecarevent.go
+++ b/api/v1/datacolumnsidecarevent.go
@@ -24,20 +24,18 @@ import (
 
 // DataColumnSidecarEvent is the data for the data column sidecar event.
 type DataColumnSidecarEvent struct {
-	BlockRoot       phase0.Root
-	Slot            phase0.Slot
-	Index           uint64
-	KZGCommitments  []deneb.KZGCommitment
-	VersionedHashes []deneb.VersionedHash
+	BlockRoot      phase0.Root
+	Slot           phase0.Slot
+	Index          uint64
+	KZGCommitments []deneb.KZGCommitment
 }
 
 // dataColumnSidecarEventJSON is the spec representation of the struct.
 type dataColumnSidecarEventJSON struct {
-	BlockRoot       string   `json:"block_root"`
-	Slot            string   `json:"slot"`
-	Index           string   `json:"index"`
-	KZGCommitments  []string `json:"kzg_commitments"`
-	VersionedHashes []string `json:"versioned_hashes"`
+	BlockRoot      string   `json:"block_root"`
+	Slot           string   `json:"slot"`
+	Index          string   `json:"index"`
+	KZGCommitments []string `json:"kzg_commitments"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -47,17 +45,11 @@ func (e *DataColumnSidecarEvent) MarshalJSON() ([]byte, error) {
 		commitments[i] = fmt.Sprintf("%#x", commitment)
 	}
 
-	hashes := make([]string, len(e.VersionedHashes))
-	for i, hash := range e.VersionedHashes {
-		hashes[i] = fmt.Sprintf("%#x", hash)
-	}
-
 	return json.Marshal(&dataColumnSidecarEventJSON{
-		BlockRoot:       fmt.Sprintf("%#x", e.BlockRoot),
-		Slot:            fmt.Sprintf("%d", e.Slot),
-		Index:           fmt.Sprintf("%d", e.Index),
-		KZGCommitments:  commitments,
-		VersionedHashes: hashes,
+		BlockRoot:      fmt.Sprintf("%#x", e.BlockRoot),
+		Slot:           fmt.Sprintf("%d", e.Slot),
+		Index:          fmt.Sprintf("%d", e.Index),
+		KZGCommitments: commitments,
 	})
 }
 
@@ -105,20 +97,6 @@ func (e *DataColumnSidecarEvent) UnmarshalJSON(input []byte) error {
 		err = e.KZGCommitments[i].UnmarshalJSON([]byte(fmt.Sprintf(`"%s"`, commitment)))
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("invalid value for kzg_commitments[%d]", i))
-		}
-	}
-
-	if len(dataColumnSidecarEventJSON.VersionedHashes) == 0 {
-		return errors.New("versioned_hashes missing")
-	}
-	e.VersionedHashes = make([]deneb.VersionedHash, len(dataColumnSidecarEventJSON.VersionedHashes))
-	for i, hash := range dataColumnSidecarEventJSON.VersionedHashes {
-		if hash == "" {
-			return fmt.Errorf("versioned_hashes[%d] missing", i)
-		}
-		err = e.VersionedHashes[i].UnmarshalJSON([]byte(fmt.Sprintf(`"%s"`, hash)))
-		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("invalid value for versioned_hashes[%d]", i))
 		}
 	}
 

--- a/api/v1/datacolumnsidecarevent_test.go
+++ b/api/v1/datacolumnsidecarevent_test.go
@@ -26,61 +26,51 @@ func TestDataColumnSidecarEventJSON(t *testing.T) {
 		},
 		{
 			name:  "BlockRootMissing",
-			input: []byte(`{"slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"]}`),
 			err:   "block_root missing",
 		},
 		{
 			name:  "BlockRootWrongType",
-			input: []byte(`{"block_root": true, "slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"block_root": true, "slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"]}`),
 			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field dataColumnSidecarEventJSON.block_root of type string",
 		},
 		{
 			name:  "BlockRootInvalid",
-			input: []byte(`{"block_root":"0xinvalide9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"block_root":"0xinvalide9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"]}`),
 			err:   "invalid value for block_root: invalid value invalide9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2: encoding/hex: invalid byte: U+0069 'i'",
 		},
 		{
 			name:  "SlotMissing",
-			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"]}`),
 			err:   "slot missing",
 		},
 		{
 			name:  "IndexMissing",
-			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"]}`),
 			err:   "index missing",
 		},
 		{
 			name:  "IndexInvalid",
-			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"-1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"-1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"]}`),
 			err:   "invalid value for index: expected integer",
 		},
 		{
 			name:  "KZGCommitmentsMissing",
-			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1"}`),
 			err:   "kzg_commitments missing",
 		},
 		{
 			name:  "KZGCommitmentsEmpty",
-			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","kzg_commitments":[],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","kzg_commitments":[]}`),
 			err:   "kzg_commitments missing",
 		},
 		{
-			name:  "VersionedHashesMissing",
-			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"]}`),
-			err:   "versioned_hashes missing",
-		},
-		{
-			name:  "VersionedHashesEmpty",
-			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"],"versioned_hashes":[]}`),
-			err:   "versioned_hashes missing",
-		},
-		{
 			name:  "Good",
-			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f"]}`),
+			input: []byte(`{"block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","slot":"1","index":"1","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363"]}`),
 		},
 		{
 			name:  "RealExample",
-			input: []byte(`{"block_root":"0xd565ec354fd256c54ff336b4d62a25312ffb0ef3004ea249cde2bf661a444ff9","slot":"127504","index":"60","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363","0x8479e2829495f00c47b1414332da60f961dba8767bbcfc8bd545b68df4966c3b4831ee1362eebe8d1d56e30b63bafb65"],"versioned_hashes":["0x01b27973b4b8de64263ccfb9068532eeff8d9e6280cd745ee754bbde6715ce2f","0x0122e2792a9b4ec6d42e16af0e028fb60dc09bffd0c48a7827db113c75eba0c2"]}`),
+			input: []byte(`{"block_root":"0xd565ec354fd256c54ff336b4d62a25312ffb0ef3004ea249cde2bf661a444ff9","slot":"127504","index":"60","kzg_commitments":["0xa590e760fdce951756d59c46b037bab8de815fe8ffc25e6e3a7b45e43289e1fdc942854cdfea1615385a0db63442f363","0x8479e2829495f00c47b1414332da60f961dba8767bbcfc8bd545b68df4966c3b4831ee1362eebe8d1d56e30b63bafb65"]}`),
 		},
 	}
 


### PR DESCRIPTION
The [fulu spec for data column sidecar](https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/das-core.md) and the [beacon API](https://github.com/Savid/beacon-APIs/blob/9addda32197c271759bb23c0cf348e4e8db7902f/apis/eventstream/index.yaml#L156-L160) doesn't have versionedHashes in data column sidecar events. 

Since the expectation of versionedHashes breaks with the existing CL implementations, this PR removes the versionedHashes from the event api. 