### PR TITLE
Automate +obol tagging

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -74,6 +74,7 @@ jobs:
           fi
 
       - name: Sync upstream tags
+        if: steps.get_latest_tag.outputs.HAS_NEW_TAG == 'true'
         run: |
           echo "Pushing tags to origin"
           git push --tags


### PR DESCRIPTION
Check every day at 09:00 if there were new tags on attestantio/go-eth2-client repository.

If there are no new tags, end workflow.

If there are new tags:
1. Fetch all new tags from upstream
2. Find the `latest_tag` (i.e.: in case of v0.26.0 and v0.26.1, pick v0.26.1)
3. Push all found tags in upstream to origin
4. Rebase branch obol on top of `latest_tag`
5. If rebase succeeds tag `latest_tag+obol`
6. If rebase fails, send message to Slack