### PR TITLE
feat(blobs): Bump max blobs to 72

### DIFF
--- a/api/blobsidecars.go
+++ b/api/blobsidecars.go
@@ -20,13 +20,13 @@ import (
 
 // BlobSidecars is an API construct to allow decoding an array of blob sidecars.
 type BlobSidecars struct {
-	Sidecars []*deneb.BlobSidecar `ssz-max:"12"`
+	Sidecars []*deneb.BlobSidecar `ssz-max:"72"`
 }
 
 // UnmarshalSSZ ssz unmarshals the BlobSidecars object.
 // This is a hand-crafted function, as automatic generation does not support immediate arrays.
 func (b *BlobSidecars) UnmarshalSSZ(buf []byte) error {
-	num, err := ssz.DivideInt2(len(buf), 131928, 12)
+	num, err := ssz.DivideInt2(len(buf), 131928, 72)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR bumps the max blobs supported to 72. While I don't believe 72 is mentioned in the `consensus-specs` repo, it's as far as core devs have been testing for PeerDAS, and the wheels start to fall off around there. 

I also considered `21`, but I think this has potential to silently break things when BPO forks activate past that point.