### PR TITLE
Fix linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,6 +112,8 @@ linters:
           disabled: true
         - name: package-directory-mismatch
           disabled: true
+        - name: package-naming
+          disabled: true
         - name: var-naming
           disabled: true
         # Configure specific rules

--- a/auto/service.go
+++ b/auto/service.go
@@ -53,7 +53,7 @@ func New(ctx context.Context, params ...Parameter) (consensusclient.Service, err
 }
 
 func tryHTTP(ctx context.Context, parameters *parameters) (consensusclient.Service, error) {
-	httpParameters := make([]http.Parameter, 0)
+	httpParameters := make([]http.Parameter, 0, 3)
 	httpParameters = append(httpParameters, http.WithLogLevel(parameters.logLevel))
 	httpParameters = append(httpParameters, http.WithAddress(parameters.address))
 	httpParameters = append(httpParameters, http.WithTimeout(parameters.timeout))

--- a/http/attesterduties.go
+++ b/http/attesterduties.go
@@ -50,7 +50,7 @@ func (s *Service) AttesterDuties(ctx context.Context,
 	}
 
 	for i := range opts.Indices {
-		if _, err := reqBodyReader.WriteString(fmt.Sprintf(`"%d"`, opts.Indices[i])); err != nil {
+		if _, err := fmt.Fprintf(&reqBodyReader, `"%d"`, opts.Indices[i]); err != nil {
 			return nil, errors.Join(errors.New("failed to write index"), err)
 		}
 

--- a/http/synccommitteeduties.go
+++ b/http/synccommitteeduties.go
@@ -49,7 +49,7 @@ func (s *Service) SyncCommitteeDuties(ctx context.Context,
 	}
 
 	for i := range opts.Indices {
-		if _, err := reqBodyReader.WriteString(fmt.Sprintf(`"%d"`, opts.Indices[i])); err != nil {
+		if _, err := fmt.Fprintf(&reqBodyReader, `"%d"`, opts.Indices[i]); err != nil {
 			return nil, errors.Join(errors.New("failed to write index"), err)
 		}
 

--- a/spec/bellatrix/executionpayload.go
+++ b/spec/bellatrix/executionpayload.go
@@ -97,7 +97,7 @@ func (e *ExecutionPayload) MarshalJSON() ([]byte, error) {
 	// big-endian for big.Int.
 	var baseFeePerGasBEBytes [32]byte
 	for i := range 32 {
-		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i] //nolint:gosec
+		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i]
 	}
 
 	baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
@@ -146,7 +146,7 @@ func (e *ExecutionPayload) MarshalYAML() ([]byte, error) {
 	// big-endian for big.Int.
 	var baseFeePerGasBEBytes [32]byte
 	for i := range 32 {
-		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i] //nolint:gosec
+		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i]
 	}
 
 	baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
@@ -393,7 +393,7 @@ func (e *ExecutionPayload) unpack(data *executionPayloadJSON) error {
 
 	baseFeeLen := len(baseFeePerGasBEBytes)
 	for i := range baseFeeLen {
-		baseFeePerGasLEBytes[i] = baseFeePerGasBEBytes[baseFeeLen-1-i] //nolint:gosec
+		baseFeePerGasLEBytes[i] = baseFeePerGasBEBytes[baseFeeLen-1-i]
 	}
 
 	copy(e.BaseFeePerGas[:], baseFeePerGasLEBytes[:])

--- a/spec/bellatrix/executionpayloadheader.go
+++ b/spec/bellatrix/executionpayloadheader.go
@@ -92,7 +92,7 @@ func (e *ExecutionPayloadHeader) MarshalJSON() ([]byte, error) {
 	// big-endian for big.Int.
 	var baseFeePerGasBEBytes [32]byte
 	for i := range 32 {
-		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i] //nolint:gosec
+		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i]
 	}
 
 	baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
@@ -136,7 +136,7 @@ func (e *ExecutionPayloadHeader) MarshalYAML() ([]byte, error) {
 	// big-endian for big.Int.
 	var baseFeePerGasBEBytes [32]byte
 	for i := range 32 {
-		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i] //nolint:gosec
+		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i]
 	}
 
 	baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
@@ -383,7 +383,7 @@ func (e *ExecutionPayloadHeader) unpack(data *executionPayloadHeaderJSON) error 
 
 	baseFeeLen := len(baseFeePerGasBEBytes)
 	for i := range baseFeeLen {
-		baseFeePerGasLEBytes[i] = baseFeePerGasBEBytes[baseFeeLen-1-i] //nolint:gosec
+		baseFeePerGasLEBytes[i] = baseFeePerGasBEBytes[baseFeeLen-1-i]
 	}
 
 	copy(e.BaseFeePerGas[:], baseFeePerGasLEBytes[:])

--- a/spec/capella/executionpayload.go
+++ b/spec/capella/executionpayload.go
@@ -103,7 +103,7 @@ func (e *ExecutionPayload) MarshalJSON() ([]byte, error) {
 	// big-endian for big.Int.
 	var baseFeePerGasBEBytes [32]byte
 	for i := range 32 {
-		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i] //nolint:gosec
+		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i]
 	}
 
 	baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
@@ -153,7 +153,7 @@ func (e *ExecutionPayload) MarshalYAML() ([]byte, error) {
 	// big-endian for big.Int.
 	var baseFeePerGasBEBytes [32]byte
 	for i := range 32 {
-		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i] //nolint:gosec
+		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i]
 	}
 
 	baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
@@ -401,7 +401,7 @@ func (e *ExecutionPayload) unpack(data *executionPayloadJSON) error {
 
 	baseFeeLen := len(baseFeePerGasBEBytes)
 	for i := range baseFeeLen {
-		baseFeePerGasLEBytes[i] = baseFeePerGasBEBytes[baseFeeLen-1-i] //nolint:gosec
+		baseFeePerGasLEBytes[i] = baseFeePerGasBEBytes[baseFeeLen-1-i]
 	}
 
 	copy(e.BaseFeePerGas[:], baseFeePerGasLEBytes[:])

--- a/spec/capella/executionpayloadheader.go
+++ b/spec/capella/executionpayloadheader.go
@@ -96,7 +96,7 @@ func (e *ExecutionPayloadHeader) MarshalJSON() ([]byte, error) {
 	// big-endian for big.Int.
 	var baseFeePerGasBEBytes [32]byte
 	for i := range 32 {
-		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i] //nolint:gosec
+		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i]
 	}
 
 	baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
@@ -141,7 +141,7 @@ func (e *ExecutionPayloadHeader) MarshalYAML() ([]byte, error) {
 	// big-endian for big.Int.
 	var baseFeePerGasBEBytes [32]byte
 	for i := range 32 {
-		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i] //nolint:gosec
+		baseFeePerGasBEBytes[i] = e.BaseFeePerGas[32-1-i]
 	}
 
 	baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
@@ -389,7 +389,7 @@ func (e *ExecutionPayloadHeader) unpack(data *executionPayloadHeaderJSON) error 
 
 	baseFeeLen := len(baseFeePerGasBEBytes)
 	for i := range baseFeeLen {
-		baseFeePerGasLEBytes[i] = baseFeePerGasBEBytes[baseFeeLen-1-i] //nolint:gosec
+		baseFeePerGasLEBytes[i] = baseFeePerGasBEBytes[baseFeeLen-1-i]
 	}
 
 	copy(e.BaseFeePerGas[:], baseFeePerGasLEBytes[:])


### PR DESCRIPTION
## Summary
- Remove stale `//nolint:gosec` directives from bellatrix and capella execution payload files (G115 already excluded globally)
- Preallocate HTTP parameters slice in `auto/service.go`
- Replace `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(...)` in `http/attesterduties.go` and `http/synccommitteeduties.go`
- Disable `package-naming` revive rule in `.golangci.yml` (the `http` package name is intentional)

## Test plan
- [x] `golangci-lint run` passes with 0 issues
- [x] `go test ./...` passes