### PR TITLE
Accept the Gloas payload-availability vote in attestation data

### DIFF
--- a/http/attestationdata.go
+++ b/http/attestationdata.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -85,6 +85,27 @@ func (s *Service) verifyAttestationData(ctx context.Context, opts *api.Attestati
 		)
 	}
 
+	onGloas, err := s.isGloasSlot(ctx, opts.Slot)
+	if err != nil {
+		return errors.Join(errors.New("failed to determine whether the slot is in the gloas era"), err)
+	}
+
+	// Gloas repurposes data.Index as a one-bit vote on the availability of the attested
+	// block's execution payload: 0 for a payload the attester does not see in the
+	// canonical chain, 1 for one it does.  Holding it to the electra-era value of 0 would
+	// discard every payload-FULL answer a conformant node gives, so bound it the way
+	// process_attestation does rather than pinning it.
+	if onGloas {
+		if data.Index > 1 {
+			return errors.Join(
+				fmt.Errorf("attestation data payload availability vote %d; expected 0 or 1", data.Index),
+				client.ErrInconsistentResult,
+			)
+		}
+
+		return nil
+	}
+
 	electraSlot, err := s.calculateElectraSlot(ctx)
 	if err != nil {
 		return errors.Join(errors.New("failed to calculate electra slot"), err)
@@ -104,6 +125,42 @@ func (s *Service) verifyAttestationData(ctx context.Context, opts *api.Attestati
 	}
 
 	return nil
+}
+
+// isGloasSlot reports whether the given slot is at or after the node's gloas fork.
+//
+// A node that does not know the fork answers false rather than failing, unlike its
+// electra counterpart's treatment of a missing key: a client publishes GLOAS_FORK_EPOCH
+// only once it has one, so on every node that predates the fork the key is simply
+// missing, and reporting that as a failure would break the endpoint everywhere.
+//
+// A predicate on a slot rather than the fork's first slot, because the two facts that
+// answer would rest on -- the epoch, and whether there is one at all -- are only
+// meaningful together.  A caller handed both separately can compare against the slot
+// without consulting the flag, and an unknown fork has no first slot to return, so that
+// mistake would admit every slot rather than none.
+func (s *Service) isGloasSlot(ctx context.Context, slot phase0.Slot) (bool, error) {
+	response, err := s.Spec(ctx, &api.SpecOpts{})
+	if err != nil {
+		return false, err
+	}
+
+	value, exists := response.Data["GLOAS_FORK_EPOCH"]
+	if !exists {
+		return false, nil
+	}
+
+	gloasEpoch, isCorrectType := value.(uint64)
+	if !isCorrectType {
+		return false, ErrIncorrectType
+	}
+
+	slotsPerEpoch, isCorrectType := response.Data["SLOTS_PER_EPOCH"].(uint64)
+	if !isCorrectType {
+		return false, ErrIncorrectType
+	}
+
+	return slot >= phase0.Slot(slotsPerEpoch*gloasEpoch), nil
 }
 
 func (s *Service) calculateElectraSlot(ctx context.Context) (phase0.Slot, error) {

--- a/http/attestationdata_test.go
+++ b/http/attestationdata_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2023 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,16 +15,177 @@ package http_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	nethttp "net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/http"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 )
+
+// attestationDataService returns a service whose every request is answered from
+// memory: the two endpoints a service needs to come up, the configuration given by
+// specEntries, and data as the answer to every attestation-data request.
+//
+// No live node can stand in for it. Which vote a conformant node returns is decided by
+// its own fork choice, so a caller cannot ask for the payload-FULL one: eight
+// consecutive requests to a Gloas devnet answered 0 every time, and a request that is
+// answered 0 exercises the same branch as every pre-Gloas answer. The other half of the
+// gate cannot be asked of that node at all, since a chain is on one side of a fork or
+// the other. Synthesising the node makes both sides reachable on demand, and reachable
+// on an endpoint that has never heard of Gloas.
+func attestationDataService(ctx context.Context,
+	t *testing.T,
+	specEntries string,
+	data *phase0.AttestationData,
+) client.Service {
+	t.Helper()
+
+	// Marshalled here rather than in the handler because a failure must be reported
+	// from the test's own goroutine.
+	encoded, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		// Both of these, or New leaves the service inactive and every call below
+		// returns ErrNotActive without ever reaching the wire.
+		case "/eth/v1/node/version":
+			fmt.Fprint(w, `{"data":{"version":"stub"}}`)
+		case "/eth/v1/node/syncing":
+			fmt.Fprint(w, `{"data":{"head_slot":"1","sync_distance":"0","is_syncing":false,"is_optimistic":false,"el_offline":false}}`)
+		case "/eth/v1/config/spec":
+			fmt.Fprintf(w, `{"data":{%s}}`, specEntries)
+		case "/eth/v1/validator/attestation_data":
+			fmt.Fprintf(w, `{"data":%s}`, encoded)
+		default:
+			w.WriteHeader(nethttp.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	service, err := http.New(ctx, http.WithAddress(server.URL))
+	require.NoError(t, err)
+
+	return service
+}
+
+// TestAttestationDataGloasPayloadVote covers the fork gate on the index assertion.
+//
+// Gloas repurposes AttestationData.index as a payload-availability vote, so the
+// Electra-era expectation that it is 0 turns a conformant node's payload-FULL answer
+// into ErrInconsistentResult and leaves the validator unable to attest on those
+// slots. What has to hold is that the two eras are told apart: bounded to {0, 1} at
+// or after the fork, pinned to 0 before it.
+func TestAttestationDataGloasPayloadVote(t *testing.T) {
+	ctx := context.Background()
+
+	const slotsPerEpoch = 32
+	// Gloas at epoch 100, so slot 3200 is the fork's first slot and 3199 its last
+	// pre-fork one.
+	const gloasForkEpoch = "100"
+	const gloasSlot = phase0.Slot(3200)
+
+	tests := []struct {
+		name string
+		// Absent from the configuration when empty, as it is on every node that
+		// does not know the fork.
+		gloasForkEpoch string
+		slot           phase0.Slot
+		index          phase0.CommitteeIndex
+		err            string
+	}{
+		{
+			// The payload-EMPTY vote, which is also every pre-Gloas value, so this
+			// is the case the electra-era expectation already admitted.
+			name:           "PayloadEmptyVoteAccepted",
+			gloasForkEpoch: gloasForkEpoch,
+			slot:           gloasSlot,
+			index:          0,
+		},
+		{
+			// The payload-FULL vote: the case that was discarded, leaving a
+			// validator client unable to attest on any slot where its node
+			// legitimately answered 1.
+			name:           "PayloadFullVoteAccepted",
+			gloasForkEpoch: gloasForkEpoch,
+			slot:           gloasSlot,
+			index:          1,
+		},
+		{
+			// Two is not a payload status.  The bound stays asserted, so widening
+			// the vote does not amount to no longer checking the field.
+			name:           "VoteAboveOneRejected",
+			gloasForkEpoch: gloasForkEpoch,
+			slot:           gloasSlot,
+			index:          2,
+			err:            "attestation data payload availability vote 2; expected 0 or 1",
+		},
+		{
+			// One slot earlier the field is still a committee index that electra
+			// zeroed, so the same answer is still inconsistent.
+			name:           "LastPreGloasSlotStillClamped",
+			gloasForkEpoch: gloasForkEpoch,
+			slot:           gloasSlot - 1,
+			index:          1,
+			err:            "attestation data for committee index 1; expected 0",
+		},
+		{
+			// A node that has never heard of the fork cannot be voting on payloads,
+			// whatever the slot number, so its answer is held to electra's rule.
+			name:  "NodeThatDoesNotKnowGloasStillClamped",
+			slot:  gloasSlot,
+			index: 1,
+			err:   "attestation data for committee index 1; expected 0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Electra at epoch 0 so that the pre-Gloas expectation in force is
+			// always the Electra-era clamp to 0, which is what the Gloas arm has
+			// to displace.
+			specEntries := fmt.Sprintf(`"SLOTS_PER_EPOCH":"%d","ELECTRA_FORK_EPOCH":"0"`, slotsPerEpoch)
+			if test.gloasForkEpoch != "" {
+				specEntries += fmt.Sprintf(`,"GLOAS_FORK_EPOCH":"%s"`, test.gloasForkEpoch)
+			}
+
+			// Slot and Index are the only fields the guard under test reads; the
+			// checkpoints are present because the response would not decode
+			// without them, not because their contents matter.
+			service := attestationDataService(ctx, t, specEntries, &phase0.AttestationData{
+				Slot:   test.slot,
+				Index:  test.index,
+				Source: &phase0.Checkpoint{},
+				Target: &phase0.Checkpoint{},
+			})
+
+			response, err := service.(client.AttestationDataProvider).AttestationData(ctx, &api.AttestationDataOpts{
+				Slot: test.slot,
+			})
+
+			if test.err != "" {
+				require.ErrorIs(t, err, client.ErrInconsistentResult)
+				require.ErrorContains(t, err, test.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.index, response.Data.Index)
+		})
+	}
+}
 
 func TestAttestationData(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Stacked on #302 — targets `gloas-port`, not `gloas`.

## The defect

`verifyAttestationData` requires `data.Index` to be `0` for every slot at or after the Electra
fork, and returns `ErrInconsistentResult` when the node disagrees:

```go
index := opts.CommitteeIndex
if opts.Slot >= electraSlot {
	index = 0
}
```

Gloas repurposes `AttestationData.index` as a one-bit vote on whether the attester sees the
attested block's execution payload in the canonical chain — `0` for absent, `1` for present —
bounded to `{0, 1}` by `assert data.index < 2` in `process_attestation`. So on a Gloas chain the
check above discards every payload-FULL answer a conformant node gives, and a validator client
on top cannot attest on those slots. There is no way to opt out.

## The change

At or after `GLOAS_FORK_EPOCH` the assertion becomes the bound `process_attestation` itself
applies. Before the fork nothing changes — the Electra-era clamp to `0` is untouched, and an
index of `1` at a pre-Gloas slot is still an inconsistent result.

The `committee_index` query parameter is deliberately left alone. beacon-APIs says it SHOULD be
omitted from Gloas onward, but live lighthouse v8.2.0 returns HTTP 400 without it, so sending it
remains the interoperable choice until a node is observed accepting the omission.

## Notes on shape

The fork is answered as a predicate on a slot — `isGloasSlot` — rather than as the fork's first
slot beside the existing `calculateElectraSlot`. The epoch and whether the node has one at all
are only meaningful together, and an unknown fork has no first slot to return, so a caller
comparing a slot against one without consulting a companion flag would admit every slot rather
than none.

A node whose configuration has no `GLOAS_FORK_EPOCH` answers `false` rather than failing. A
client publishes the epoch only once it has one, so treating the missing key the way
`calculateElectraSlot` treats its own would break this endpoint on every node that predates the
fork.

One consequence worth naming: `isGloasSlot` and `calculateElectraSlot` each read the cached spec
separately, so a pre-Gloas verification now performs two cached reads where it performed one.
Folding them into a single read means changing `calculateElectraSlot`'s signature, which is not
worth it for nanoseconds on a path that does no I/O.

## Verification

A table-driven test answers every request from its own `httptest` server, so it needs no beacon
node at all. That is not convenience: which vote a conformant node returns is decided by its own
fork choice, so a caller cannot ask for the payload-FULL one — eight consecutive live requests to
a Gloas devnet answered `0`, which exercises the same branch as every pre-Gloas answer. And the
pre-fork half of the gate cannot be asked of that node at all, since a chain sits on one side of
a fork or the other.

Five rows: payload-EMPTY accepted, payload-FULL accepted, a vote above `1` rejected, the last
pre-Gloas slot still clamped, and a node that has never heard of the fork still clamped. Each was
checked to be load-bearing by mutating the guard and confirming exactly that row failed —
widening the bound to `> 2`, treating a missing fork epoch as in-era, and shifting the fork
boundary one slot early each killed one row and only that row.

`go build ./...`, `gosilent test ./...` (2423 tests), `-race`, and `./custom-gcl run` are all
clean, and the live attestation-data tests still pass against a Gloas devnet under `-p 1`.