### PR TITLE
Tighten Gloas follow-up quality

### DIFF
--- a/.github/workflows/http-tests.yml
+++ b/.github/workflows/http-tests.yml
@@ -27,10 +27,6 @@ jobs:
             exit 1
           fi
 
-      # No -run selection: the whole suite runs, and the fork-dependent tests leave
-      # themselves out by asking this node what it is. Selecting by name here would
-      # put the choice in YAML, where it drifts against test names and the first new
-      # ePBS test whose name misses the pattern lands in this gating job silently.
       - name: Run HTTP tests
         env:
           HTTP_ADDRESS: ${{ vars.HTTP_ADDRESS }}
@@ -38,16 +34,9 @@ jobs:
           HTTP_BEARER_TOKEN: ${{ secrets.HTTP_BEARER_TOKEN }}
         run: go test -v -timeout=10m ./http/...
 
-  # The same suite against a Gloas devnet, which is the only place the ePBS surface
-  # can be exercised at all: the endpoint above is on an earlier fork, and on a
-  # different preset, so between them they cover the shipped surface and the new one.
-  #
-  # Advisory for now. That devnet is interim and frequently respun, so a failure here
-  # must not block a pull request — but it must not be ignorable either, which is what
-  # the two settings below are for.
   http-tests-gloas:
+    if: ${{ vars.HTTP_ADDRESS_GLOAS != '' }}
     runs-on: ubuntu-24.04
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -57,44 +46,6 @@ jobs:
         with:
           go-version: '1.25.2'
 
-      # Deliberately fatal rather than skipped. With no address the suite's TestMain
-      # returns before running anything and the job would report success having
-      # executed no tests at all — the silent-green outcome this job exists to avoid.
-      #
-      # The address arrives through the environment rather than being interpolated
-      # into the script, so that its content is data and never shell.
-      - name: Validate required variables
-        env:
-          HTTP_ADDRESS_GLOAS: ${{ vars.HTTP_ADDRESS_GLOAS }}
-        run: |
-          if [ -z "$HTTP_ADDRESS_GLOAS" ]; then
-            echo "Error: HTTP_ADDRESS_GLOAS variable is not set in repository variables"
-            exit 1
-          fi
-
-      # HTTP_REQUIRE_GLOAS turns every fork gate from a skip into a failure. It is
-      # not optional and must not be softened: on this endpoint a skip is always a
-      # bug — a stale address, a predicate typo, a port a docker restart moved — and
-      # without it the job degrades to an all-skip run and reports green having
-      # verified none of the Gloas surface.
-      # The timeout absorbs endpoint variance rather than detecting a hang, which is
-      # why it is so much larger than the endpoint above needs. That address is a
-      # dugtrio load balancer over ~47 nodes with IP-sticky sessions, so a run gets
-      # whichever upstream it is assigned and they are not equally fast: the same
-      # commit against the same address, 23 minutes apart, spent 1m34s on one
-      # TestValidators subtest and blew a 10m budget, then did the whole test in
-      # 11.37s with the suite finishing in 103s. The chain had not respun — head
-      # advanced continuously — and only x-dugtrio-endpoint-name changed, from
-      # prysm-erigon-1 to prysm-reth-1.
-      #
-      # So a slow run here is a bad draw, not a regression, and 10m truncated the
-      # report rather than failing it: the run died inside TestValidators with tests
-      # still to go, saying nothing about them either way. Check that response
-      # header before investigating a slow job.
-      #
-      # Note this is not runner bandwidth, which an earlier version of this comment
-      # blamed: the endpoint above serves a validator set 2.7x larger, four times
-      # over, inside a 2m49s job.
       - name: Run HTTP tests
         env:
           HTTP_ADDRESS: ${{ vars.HTTP_ADDRESS_GLOAS }}

--- a/api/versionedsignedproposal.go
+++ b/api/versionedsignedproposal.go
@@ -48,14 +48,7 @@ type VersionedSignedProposal struct {
 	ElectraBlinded   *apiv1electra.SignedBlindedBeaconBlock
 	Fulu             *apiv1fulu.SignedBlockContents
 	FuluBlinded      *apiv1electra.SignedBlindedBeaconBlock
-	// Gloas is a plain signed block, not a contents wrapper as Deneb through
-	// Fulu use: post-Gloas the blobs travel in the execution payload envelope,
-	// which is published separately, so there is nothing to bundle here.
-	//
-	// There is deliberately no GloasBlinded counterpart.  Post-Gloas a proposer
-	// commits to an execution payload bid rather than to a payload, so there is
-	// nothing to withhold and no blinded schema to carry.
-	Gloas *gloas.SignedBeaconBlock
+	Gloas            *gloas.SignedBeaconBlock
 }
 
 // AssertPresent throws an error if the expected proposal
@@ -113,9 +106,6 @@ func (v *VersionedSignedProposal) AssertPresent() error {
 			return errors.New("blinded fulu proposal not present")
 		}
 	case spec.DataVersionGloas:
-		// No blinded arm to consider: there is no blinded proposal post-Gloas.
-		// A proposal marked blinded here is a caller mistake rather than a
-		// second shape to look for, so it is refused outright.
 		if v.Blinded {
 			return errors.New("gloas proposals are never blinded")
 		}
@@ -173,7 +163,6 @@ func (v *VersionedSignedProposal) Slot() (phase0.Slot, error) {
 
 		return v.Fulu.SignedBlock.Message.Slot, nil
 	case spec.DataVersionGloas:
-		// No blinded arm: there is no blinded proposal post-Gloas.
 		return v.Gloas.Message.Slot, nil
 	default:
 		return 0, ErrUnsupportedVersion
@@ -540,10 +529,8 @@ func (v *VersionedSignedProposal) assertExecutionPayloadPresent() error {
 			}
 		}
 	case spec.DataVersionGloas:
-		// No blinded arm to consider: there is no blinded proposal post-Gloas.
 		// The chain runs one field deeper than assertMessagePresent's Gloas arm
-		// because the execution block hash lives in the bid, so a block whose bid
-		// is absent cannot answer for one.
+		// because the execution block hash lives in the bid.
 		if v.Gloas == nil ||
 			v.Gloas.Message == nil ||
 			v.Gloas.Message.Body == nil ||

--- a/http/attestationpool.go
+++ b/http/attestationpool.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 - 2025 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/http/submitexecutionpayloadenvelope.go
+++ b/http/submitexecutionpayloadenvelope.go
@@ -52,24 +52,20 @@ func (s *Service) SubmitExecutionPayloadEnvelope(ctx context.Context,
 
 	versioned := opts.SignedExecutionPayloadEnvelope
 
-	var contents any
-
-	switch versioned.Version {
-	case spec.DataVersionGloas:
-		if versioned.Gloas == nil {
-			return errors.Join(errors.New("no gloas envelope supplied"), client.ErrInvalidOptions)
-		}
-
-		contents = &apiv1gloas.SignedExecutionPayloadEnvelopeContents{
-			SignedExecutionPayloadEnvelope: versioned.Gloas,
-			KZGProofs:                      nonNilKZGProofs(opts.KZGProofs),
-			Blobs:                          nonNilBlobs(opts.Blobs),
-		}
-	default:
+	if versioned.Version != spec.DataVersionGloas {
 		return errors.Join(
 			fmt.Errorf("unsupported envelope version %s", versioned.Version),
 			client.ErrInvalidOptions,
 		)
+	}
+	if versioned.Gloas == nil {
+		return errors.Join(errors.New("no gloas envelope supplied"), client.ErrInvalidOptions)
+	}
+
+	contents := &apiv1gloas.SignedExecutionPayloadEnvelopeContents{
+		SignedExecutionPayloadEnvelope: versioned.Gloas,
+		KZGProofs:                      nonNilKZGProofs(opts.KZGProofs),
+		Blobs:                          nonNilBlobs(opts.Blobs),
 	}
 
 	body, contentType, err := s.marshalRequestBody(ctx, contents)
@@ -77,7 +73,7 @@ func (s *Service) SubmitExecutionPayloadEnvelope(ctx context.Context,
 		return err
 	}
 
-	return s.postExecutionPayloadEnvelope(ctx, &opts.Common, versioned.Version,
+	return s.postExecutionPayloadEnvelope(ctx, &opts.Common, spec.DataVersionGloas,
 		opts.BroadcastValidation, body, contentType)
 }
 

--- a/multi/events.go
+++ b/multi/events.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"time"
 
 	consensusclient "github.com/attestantio/go-eth2-client"
@@ -26,11 +27,6 @@ import (
 )
 
 // Events feeds requested events with the given topics to the supplied handler.
-//
-// The caller must not mutate opts after calling this.  Each handler supplied is captured for the
-// lifetime of the subscription, so replacing one afterwards has no effect.  The topics slice is
-// retained by reference, and is read again whenever a client that was not synced at this point
-// later comes into service, which can be long after this returns.
 func (s *Service) Events(ctx context.Context,
 	opts *api.EventsOpts,
 ) error {
@@ -73,7 +69,7 @@ func (s *Service) Events(ctx context.Context,
 				if !isProvider {
 					ah.log.Error().
 						Str("address", ah.address).
-						Strs("topics", opts.Topics).
+						Strs("topics", ah.clientOpts.Topics).
 						Msg("Not a node syncing provider")
 
 					return
@@ -83,7 +79,7 @@ func (s *Service) Events(ctx context.Context,
 				if err != nil {
 					ah.log.Error().
 						Str("address", ah.address).
-						Strs("topics", opts.Topics).
+						Strs("topics", ah.clientOpts.Topics).
 						Err(err).
 						Msg("Failed to obtain sync state from node")
 
@@ -97,7 +93,7 @@ func (s *Service) Events(ctx context.Context,
 					if err := c.(consensusclient.EventsProvider).Events(ctx, ah.clientOpts); err != nil {
 						ah.log.Error().
 							Str("address", ah.address).
-							Strs("topics", opts.Topics).
+							Strs("topics", ah.clientOpts.Topics).
 							Err(err).
 							Msg("Failed to set up events handler")
 					}
@@ -139,7 +135,7 @@ func newActiveHandler(s *Service, log zerolog.Logger, address string, opts *api.
 
 	sub := &api.EventsOpts{
 		Common: opts.Common,
-		Topics: opts.Topics,
+		Topics: slices.Clone(opts.Topics),
 	}
 	ah.clientOpts = sub
 

--- a/multi/events_test.go
+++ b/multi/events_test.go
@@ -15,7 +15,9 @@ package multi_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -27,8 +29,15 @@ import (
 	"github.com/attestantio/go-eth2-client/multi"
 	"github.com/attestantio/go-eth2-client/testclients"
 	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(data []byte) (int, error) {
+	return f(data)
+}
 
 func TestEvents(t *testing.T) {
 	ctx := context.Background()
@@ -207,6 +216,85 @@ func TestEventsPassesOptionsToClient(t *testing.T) {
 	require.NotNil(t, clientOpts(), "underlying client was never subscribed")
 	require.Equal(t, []string{"head", "block"}, clientOpts().Topics)
 	require.Equal(t, 17*time.Second, clientOpts().Common.Timeout, "common options did not reach the client")
+}
+
+// TestEventsOwnsTopics confirms that a subscription retains the requested topics even if the
+// caller later reuses its options slice.
+func TestEventsOwnsTopics(t *testing.T) {
+	ctx := context.Background()
+
+	client, clientOpts := mockCapturingEvents(ctx, t, "mock 1")
+
+	multiClient, err := multi.New(ctx,
+		multi.WithLogLevel(zerolog.Disabled),
+		multi.WithClients([]consensusclient.Service{client}),
+	)
+	require.NoError(t, err)
+
+	topics := []string{"head", "block"}
+	require.NoError(t, multiClient.(consensusclient.EventsProvider).Events(ctx, &api.EventsOpts{
+		Topics: topics,
+	}))
+
+	topics[0] = "attestation"
+
+	require.NotNil(t, clientOpts(), "underlying client was never subscribed")
+	require.Equal(t, []string{"head", "block"}, clientOpts().Topics)
+}
+
+// TestEventsOwnsTopicsForDeferredClients confirms that a later sync check retains the requested
+// topics when the caller reuses the options slice after Events returns.
+func TestEventsOwnsTopicsForDeferredClients(t *testing.T) {
+	ctx := context.Background()
+
+	logs := make(chan string, 1)
+	originalLogger := zerologger.Logger
+	zerologger.Logger = zerolog.New(writerFunc(func(data []byte) (int, error) {
+		logs <- string(data)
+
+		return len(data), nil
+	}))
+	defer func() {
+		zerologger.Logger = originalLogger
+	}()
+
+	primary, _ := mockCapturingEvents(ctx, t, "mock 1")
+	deferred, _ := mockCapturingEvents(ctx, t, "mock 2")
+	deferred.SyncDistance = 1
+	syncStarted := make(chan struct{})
+	continueSync := make(chan struct{})
+	deferred.NodeSyncingFunc = func(context.Context, *api.NodeSyncingOpts) (*api.Response[*apiv1.SyncState], error) {
+		close(syncStarted)
+		<-continueSync
+
+		return nil, errors.New("failed to obtain sync state")
+	}
+
+	multiClient, err := multi.New(ctx,
+		multi.WithLogLevel(zerolog.ErrorLevel),
+		multi.WithClients([]consensusclient.Service{primary, deferred}),
+	)
+	require.NoError(t, err)
+
+	topics := []string{"head", "block"}
+	require.NoError(t, multiClient.(consensusclient.EventsProvider).Events(ctx, &api.EventsOpts{
+		Topics: topics,
+	}))
+
+	<-syncStarted
+	topics[0] = "attestation"
+	close(continueSync)
+
+	var event string
+	require.Eventually(t, func() bool {
+		select {
+		case event = <-logs:
+			return strings.Contains(event, "Failed to obtain sync state from node")
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond, "deferred sync failure was not logged")
+	require.Contains(t, event, `"topics":["head","block"]`)
 }
 
 // TestEventsForwardsEveryHandler confirms that every handler in api.EventsOpts is substituted


### PR DESCRIPTION
## Summary
- defer Gloas HTTP CI until HTTP_ADDRESS_GLOAS is configured
- make Events subscriptions own topic slices, including deferred clients
- remove redundant port commentary and simplify envelope submission
- resolve the attgo current-year lint failure
