### PR TITLE
Tidy ups for ePBS changes.

### DIFF
--- a/http/epbsproposal.go
+++ b/http/epbsproposal.go
@@ -38,6 +38,13 @@ import (
 // generous room for any real value while keeping a hostile one cheap to reject.
 const maxProposalValueDigits = 40
 
+// maxEPBSResponseSize bounds the bodies of the ePBS fetch endpoints, the
+// largest of which is a payload-included block-contents response.  That carries
+// up to MAX_BLOB_COMMITMENTS_PER_BLOCK blobs at 128KiB each plus the block and
+// envelope; 64MiB leaves generous headroom over any current preset's blob count
+// while capping a hostile or runaway response.  Note this same value is also
+// passed to post() (see http.go), so it bounds every POST response body across
+// the library, not just the ePBS endpoints.
 const maxEPBSResponseSize = 64 * 1024 * 1024
 
 // EPBSProposal fetches a potential ePBS beacon block for signing.
@@ -349,9 +356,10 @@ func epbsPayloadIncludedFromHeaders(headers map[string]string) (bool, error) {
 	return false, errors.New("no Eth-Execution-Payload-Included header in epbs proposal response")
 }
 
-// epbsPayloadIncludedFromBody reads the payload-inclusion flag from a JSON
-// response body.  The flag selects which of the two containers the data field
-// carries, so it has to be read before the data itself can be decoded.
+// decodeEPBSProposalJSON reads the payload-inclusion flag from a JSON response
+// body and decodes the data into the container it selects.  The flag selects
+// which of the two containers the data field carries, so it has to be read
+// before the data itself can be decoded.
 func decodeEPBSProposalJSON(body []byte, proposal *api.VersionedEPBSProposal) (map[string]any, error) {
 	response := make(map[string]json.RawMessage)
 	if err := json.Unmarshal(body, &response); err != nil {

--- a/http/signedexecutionpayloadenvelope.go
+++ b/http/signedexecutionpayloadenvelope.go
@@ -41,6 +41,18 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 		return nil, err
 	}
 
+	return s.signedExecutionPayloadEnvelopeFromResponse(ctx, httpResponse)
+}
+
+// signedExecutionPayloadEnvelopeFromResponse decodes a fetched signed envelope
+// response.  It is separate from the fetch so that both encodings, and the
+// empty-response guard, stay testable without a node serving the endpoint.
+func (s *Service) signedExecutionPayloadEnvelopeFromResponse(ctx context.Context,
+	httpResponse *httpResponse,
+) (
+	*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope],
+	error,
+) {
 	// The envelope is a gloas-onwards container, so the wire bytes always
 	// parse into *gloas.SignedExecutionPayloadEnvelope.
 	envelope := &gloas.SignedExecutionPayloadEnvelope{}
@@ -60,12 +72,23 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 			)
 		}
 	case ContentTypeJSON:
-		decoded, jsonMetadata, err := decodeJSONResponse(bytes.NewReader(httpResponse.body), envelope)
+		// Seeded with a typed nil pointer so that a body with no data key in it
+		// is distinguishable from one carrying a zero-valued envelope, matching
+		// the sibling unsigned-envelope endpoint.  decodeJSONResponse only
+		// unmarshals when a data key is present and does not error when it is
+		// absent, so a non-nil seed would return a zero-valued envelope as
+		// success and every downstream accessor would read garbage.
+		decoded, jsonMetadata, err := decodeJSONResponse(bytes.NewReader(httpResponse.body),
+			(*gloas.SignedExecutionPayloadEnvelope)(nil))
 		if err != nil {
 			return nil, errors.Join(
 				fmt.Errorf("failed to decode %s signed execution payload envelope", httpResponse.consensusVersion),
 				err,
 			)
+		}
+
+		if decoded == nil {
+			return nil, fmt.Errorf("no %s signed execution payload envelope in response", httpResponse.consensusVersion)
 		}
 
 		envelope = decoded

--- a/http/signedexecutionpayloadenvelope_internal_test.go
+++ b/http/signedexecutionpayloadenvelope_internal_test.go
@@ -1,0 +1,135 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+)
+
+// validSignedExecutionPayloadEnvelope wraps the package's shared valid envelope
+// (defined alongside the unsigned endpoint's test) in a signature so its own
+// marshalers run.
+func validSignedExecutionPayloadEnvelope() *gloas.SignedExecutionPayloadEnvelope {
+	return &gloas.SignedExecutionPayloadEnvelope{
+		Message:   validExecutionPayloadEnvelope(),
+		Signature: phase0.BLSSignature{0x01, 0x02},
+	}
+}
+
+// TestSignedExecutionPayloadEnvelopeFromResponse covers the decode half of the
+// endpoint.  Splitting decode from the fetch is what lets the SSZ body and the
+// error paths be exercised without a node serving the route.
+func TestSignedExecutionPayloadEnvelopeFromResponse(t *testing.T) {
+	ctx := context.Background()
+	s := &Service{}
+
+	envelope := validSignedExecutionPayloadEnvelope()
+
+	envelopeJSON, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	jsonBody := fmt.Appendf(nil, `{"version":"gloas","data":%s}`, envelopeJSON)
+
+	t.Run("JSON", func(t *testing.T) {
+		response, err := s.signedExecutionPayloadEnvelopeFromResponse(ctx, &httpResponse{
+			statusCode:       http.StatusOK,
+			contentType:      ContentTypeJSON,
+			consensusVersion: spec.DataVersionGloas,
+			body:             jsonBody,
+			headers:          map[string]string{},
+		})
+		require.NoError(t, err)
+		require.Equal(t, spec.DataVersionGloas, response.Data.Version)
+		require.NotNil(t, response.Data.Gloas)
+		require.False(t, response.Data.IsEmpty())
+	})
+
+	t.Run("SSZ", func(t *testing.T) {
+		sszBody, err := envelope.MarshalSSZ()
+		require.NoError(t, err)
+
+		response, err := s.signedExecutionPayloadEnvelopeFromResponse(ctx, &httpResponse{
+			statusCode:       http.StatusOK,
+			contentType:      ContentTypeSSZ,
+			consensusVersion: spec.DataVersionGloas,
+			body:             sszBody,
+			headers:          map[string]string{},
+		})
+		require.NoError(t, err)
+
+		// SSZ carries no field names, so a wrongly ordered codec shows up as a
+		// differing hash tree root rather than a decode error.
+		want, err := envelope.HashTreeRoot()
+		require.NoError(t, err)
+		got, err := response.Data.Gloas.HashTreeRoot()
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	// The regression this file exists for.  decodeJSONResponse only unmarshals
+	// when a data key is present and does not error when it is absent, so a body
+	// with no data key (or an explicit null) must be rejected rather than
+	// returned as a zero-valued envelope whose every accessor reads garbage.
+	// Before the typed-nil seed and this guard, the non-nil seed made both
+	// bodies decode as success.
+	t.Run("NoDatum", func(t *testing.T) {
+		for _, body := range []string{
+			`{"version":"gloas"}`,
+			`{"version":"gloas","data":null}`,
+		} {
+			_, err := s.signedExecutionPayloadEnvelopeFromResponse(ctx, &httpResponse{
+				statusCode:       http.StatusOK,
+				contentType:      ContentTypeJSON,
+				consensusVersion: spec.DataVersionGloas,
+				body:             []byte(body),
+				headers:          map[string]string{},
+			})
+			require.ErrorContains(t, err, "no gloas signed execution payload envelope in response")
+		}
+	})
+
+	t.Run("CorruptSSZ", func(t *testing.T) {
+		sszBody, err := envelope.MarshalSSZ()
+		require.NoError(t, err)
+
+		_, err = s.signedExecutionPayloadEnvelopeFromResponse(ctx, &httpResponse{
+			statusCode:       http.StatusOK,
+			contentType:      ContentTypeSSZ,
+			consensusVersion: spec.DataVersionGloas,
+			body:             sszBody[:len(sszBody)-1],
+			headers:          map[string]string{},
+		})
+		require.ErrorContains(t, err, "failed to decode gloas signed execution payload envelope")
+	})
+
+	t.Run("UnknownContentType", func(t *testing.T) {
+		_, err := s.signedExecutionPayloadEnvelopeFromResponse(ctx, &httpResponse{
+			statusCode:       http.StatusOK,
+			contentType:      ContentTypeUnknown,
+			consensusVersion: spec.DataVersionGloas,
+			body:             jsonBody,
+			headers:          map[string]string{},
+		})
+		require.ErrorContains(t, err, "unhandled content type")
+	})
+}

--- a/multi/signedexecutionpayloadenvelope.go
+++ b/multi/signedexecutionpayloadenvelope.go
@@ -29,12 +29,12 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 	error,
 ) {
 	res, err := s.doCall(ctx, func(ctx context.Context, client consensusclient.Service) (any, error) {
-		block, err := client.(consensusclient.ExecutionPayloadProvider).SignedExecutionPayloadEnvelope(ctx, opts)
+		envelope, err := client.(consensusclient.ExecutionPayloadProvider).SignedExecutionPayloadEnvelope(ctx, opts)
 		if err != nil {
 			return nil, err
 		}
 
-		return block, nil
+		return envelope, nil
 	}, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Addresses review concerns found on #310 (`review/epbs-block-production-transport`). The headline is one real correctness bug in the signed-envelope fetch path; the rest are a matching test, a doc-comment fix, and small clarity cleanups.

## What & why

### 🐛 Fix: `SignedExecutionPayloadEnvelope` silently accepted an empty response
`http/signedexecutionpayloadenvelope.go` seeded a **non-nil** `&gloas.SignedExecutionPayloadEnvelope{}` and passed it to `decodeJSONResponse`. That helper only unmarshals when a `data` key is present and does **not** error when it's absent — so a body like `{"version":"gloas"}` or `{"version":"gloas","data":null}` decoded to a zero-valued envelope and was returned as **success**, leaving every downstream accessor reading garbage (and skipping the container's required-field validation, which only runs when `data` is present).

The sibling endpoint (`executionpayloadenvelope.go`) already does this correctly: it seeds a **typed nil** and checks `decoded == nil`. This PR makes the signed endpoint consistent — typed-nil seed + nil check — and splits decode into `signedExecutionPayloadEnvelopeFromResponse` so both encodings and the empty-response guard are testable without a live node.

### ✅ Test: cover the endpoint that had none
Adds `http/signedexecutionpayloadenvelope_internal_test.go` covering JSON, SSZ, **no-data (the regression)**, corrupt-SSZ, and unknown-content-type. `SignedExecutionPayloadEnvelope` was the one ePBS endpoint without decode-path coverage.

### 🧹 Cleanups
- `http/epbsproposal.go`: fix a stale doc comment that named a nonexistent `epbsPayloadIncludedFromBody`; document `maxEPBSResponseSize` (its 64 MiB blob-count assumption, and that it now bounds **every** POST response body library-wide via `post()`).
- `multi/signedexecutionpayloadenvelope.go`: rename misleading `block` variable → `envelope`.
- `service.go`: expand `ExecutionPayloadProvider` godoc to explain how it differs from `ExecutionPayloadEnvelopeProvider` (reads a published, **signed** envelope vs. collects a node's cached **unsigned** one). No rename — that would break the #311/#316 restack.

## Scope / stacking
No interface renames or signature changes, so #311–#316 should restack cleanly. Intended to be folded into #310 (or merged into `review/epbs-block-production-transport`).
