### PR TITLE
feat: add MultiForkProposalProvider

### DIFF
--- a/service.go
+++ b/service.go
@@ -353,6 +353,22 @@ type EPBSProposalProvider interface {
 	)
 }
 
+// MultiForkProposalProvider is the interface for providing proposals on either
+// side of the gloas fork.
+//
+// It composes the two proposal providers rather than adding an endpoint of its
+// own.  ProposalProvider is frozen at the last pre-gloas fork and
+// EPBSProposalProvider is gloas-onwards only, so a caller that must produce
+// blocks across the fork boundary needs both; this states that requirement as
+// one type instead of leaving each caller to compose it.
+//
+// "MultiFork" is the number of forks spanned, not the number of nodes: it is
+// unrelated to the multi package.
+type MultiForkProposalProvider interface {
+	ProposalProvider
+	EPBSProposalProvider
+}
+
 // ExecutionPayloadEnvelopeProvider is the interface for providing the execution
 // payload envelope a node cached while producing a block.
 //


### PR DESCRIPTION
## What

Adds `MultiForkProposalProvider` to `service.go`:

```go
type MultiForkProposalProvider interface {
	ProposalProvider
	EPBSProposalProvider
}
```

A composition of two interfaces that already exist. No new endpoint, no
implementation change, nothing outside `service.go`.

## Why

`EPBSProposalProvider`'s doc comment already says it:

> It sits alongside ProposalProvider rather than replacing it: the endpoint
> behind it is gloas-onwards only, and the endpoint behind ProposalProvider is
> frozen at the last pre-gloas fork, so a client needs both to span the fork.

That last clause is the contract. It is also just prose, so every consumer that
produces blocks across the fork boundary has to work it out again, compose the
pair itself, then type-assert a locally declared shape against a client the
library handed it. This makes the requirement a type instead.

vouch declares exactly this composition today and asserts against it. The intent
is for it to consume this instead.

## On the name

`Multi-` already means three different things here. The `multi` package counts
beacon nodes. vouch's multi-instance counts processes. This counts forks. So
`MultiProposalProvider` is ambiguous at best, and at worst it parses as "the
`multi` package's proposal provider", which is the wrong axis entirely. Written
out, `_ client.MultiProposalProvider = (*multi.Service)(nil)` reads as a
tautology on the one line a reviewer checks for conformance. Naming the axis
costs one word.

`ProposalDataProvider`, the name it currently has in vouch, does not survive the
move either. Here `*DataProvider` names the type returned, so
`AttestationDataProvider` gives you `phase0.AttestationData`. There is no
`ProposalData`, and the name would promise an endpoint that does not exist.

## Open questions, genuinely open

1. **No parity assertions, deliberately.** `providerparity_test.go` keeps
   endpoint implementations in parity. This adds no endpoint, and anything
   satisfying both constituents satisfies the composite for free, so assertions
   here would restate what the existing five-per-interface assertions already
   cover. I lean towards leaving them out, but I will add the five lines if you
   would rather see it stated.

2. **The only precedent is an orphan.** `ValidatorIDProvider`
   (`service.go:104`) is the library's other composite interface. Zero consumers
   across attestantio and wealdtech, and no parity assertion. That is a fair
   argument that composites shaped for consumers do not survive here, and it is
   the main reason this is a draft rather than ready for review.

3. **One consumer today.** Only vouch produces blocks. ethdo, chaind and
   ethereal have no proposal-provider usage at all. The case rests on the library
   owning the split it created, not on having many callers to spread the cost
   over.

4. **Lifetime.** `ProposalProvider` is not going anywhere while any supported
   network sits pre-gloas, so this is durable API rather than a stopgap. Worth
   saying, because the obvious reading is the opposite.

## Verification

`go build ./...`, `go vet .` and `gofmt -l` are clean. `custom-gcl run` on the
root package with issue caps disabled reports 0 issues. `gosilent test ./...`
gives 7 failed, 14 passed, byte-identical to `origin/gloas`: go1.27 reworded some
`encoding/json` errors and the spec tests assert on that text.

One unrelated snag worth flagging. `.custom-gcl.yml` pins golangci-lint `v2.8.0`,
which cannot read go1.27 export data, so the pinned gate dies with `typecheck`
errors on stdlib imports before it reaches any project code. I got the clean run
above by building the plugin against `v2.13.1` locally. That pin change is not in
this PR. It does mean the pinned gate currently passes without checking anything
on go1.27, which looks worth a separate fix.
