### PR TITLE
chore: bump golangci-lint pin to v2.13.1

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,4 @@
-version: v2.8.0
+version: v2.13.1
 name: custom-gcl
 
 plugins:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build custom golangci-lint
         if: steps.cache-custom-gcl.outputs.cache-hit != 'true'
         run: |
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
           golangci-lint custom
 
       # Make custom binary available as golangci-lint in PATH

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,12 +41,14 @@ linters:
     - err113           # Disable error 113 check
     - exhaustive       # Disable exhaustive check
     - exhaustruct      # Disable exhaustruct check
+    - exhaustruct_v5   # Disable exhaustruct check
     - forcetypeassert  # Disable force type assert check
     - funlen           # Disable function length check
     - gochecknoglobals # Disable global variable check
     - gochecknoinits   # Disable global variable check
     - gocognit         # Disable cognitive complexity check
     - goconst          # Disable constant check
+    - gomodguard       # Superseded by gomodguard_v2, which default: all enables
     - intrange         # Disable integer range check
     - ireturn          # Disable return check
     - lll              # Disable line length check


### PR DESCRIPTION
## Why

A `custom-gcl` built from the `v2.8.0` pin cannot read the export data of a newer Go toolchain. On Go 1.27 it fails with

```
export data version 4 is greater than maximum supported version 2
```

then reports a few `(typecheck)` import errors and stops. Every linter that needs type information analyses nothing.

The failure mode is what makes this worth fixing. The run does not look broken, it looks quiet. Two issues where a working gate finds ten, and both of those two are import complaints you would skim past on the way to the summary line.

CI is unaffected today, because `golangci-lint.yml` still pins Go 1.25. The reason to fix it now is `update-go-version.yml`. That workflow rewrites `go-version:` in every workflow file when a new Go ships, and it touches neither golangci-lint pin. The first time the bot moves this repo to 1.27, the gate goes quiet in CI exactly as it does locally, and nothing in the output says so.

## What changed

Four edits across three files.

The version is pinned twice, and both pins have to move together:

- `.custom-gcl.yml`, the `version:` key that `golangci-lint custom` reads when it builds the binary.
- `.github/workflows/golangci-lint.yml`, the `go install ...@v2.8.0` line that installs the builder.

Both now say `v2.13.1`.

`.golangci.yml` gains two `disable` entries, and neither is housekeeping I tacked on:

- `exhaustruct_v5`. v2.13.1 ships it beside `exhaustruct`, so `default: all` turns it on and the existing `- exhaustruct` line stops meaning what it says. Without this entry, 50 findings appear across `api/`. The config already handles this same rename for `wsl` and `wsl_v5`, so I followed that.
- `gomodguard`. v2.13.1 deprecates it in favour of `gomodguard_v2`, which `default: all` already enables. Disabling the old one silences the deprecation warning and leaves the same ten findings, which figures: `gomodguard` has no settings block in this repo, so it had no module list to enforce.

The workflow caches the binary under `hashFiles('.custom-gcl.yml')`, so the bump invalidates the cache by itself and CI rebuilds on the first run.

## Verification

I built `custom-gcl` from the new config and ran it over the whole repo at this branch's base.

Ten issues, all in code this PR does not touch: two `attgo_current_year`, five unused `//nolint:gosec` directives in `spec/bellatrix/`, one `revive` package-naming in `http/`, two `staticcheck` SA1019 deprecations in `http/`. The bump introduces none of them, and the count is identical with and without the `gomodguard` entry.

A low issue count is not evidence the gate works, though. That is the exact failure this PR fixes. So I planted an `nlreturn` violation in `http/spec.go` and confirmed the new gate flags it:

```
http/spec.go:97:2: return with no blank line before (nlreturn)
```

The `v2.8.0` binary says nothing about the same line. Probe reverted.

No Go files change here, so `only-new-issues: true` has no changed lines to attach anything to.
